### PR TITLE
Functional interfaces

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ repositories {
 dependencies {
     // 1.12.2 is the oldest version we plan on officially supporting
     compileOnly("org.spigotmc:spigot-api:1.12.2-R0.1-SNAPSHOT")
+    compileOnly("org.jetbrains:annotations:24.1.0")
 }
 
 kotlin {

--- a/platforms/folia/src/main/kotlin/com/cjcrafter/scheduler/folia/FoliaAsyncScheduler.kt
+++ b/platforms/folia/src/main/kotlin/com/cjcrafter/scheduler/folia/FoliaAsyncScheduler.kt
@@ -7,51 +7,53 @@ import org.bukkit.plugin.Plugin
 import org.jetbrains.annotations.ApiStatus
 import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
+import java.util.function.Function
 
 @ApiStatus.Internal
 internal class FoliaAsyncScheduler(private val plugin: Plugin) : AsyncSchedulerImplementation {
 
     private val asyncScheduler = plugin.server.asyncScheduler
 
-    override fun runNow(consumer: Consumer<TaskImplementation>): TaskImplementation {
-        val taskImplementation = FoliaTask()
-        val foliaConsumer: Consumer<ScheduledTask> = Consumer { scheduledTask ->
+    private fun <T : Any> buildFoliaConsumer(
+        taskImplementation: FoliaTask<T>,
+        function: Function<TaskImplementation<T>, T>,
+    ): Consumer<ScheduledTask> {
+        return Consumer { scheduledTask ->
             taskImplementation.scheduledTask = scheduledTask  // updating is probably not necessary
-            consumer.accept(taskImplementation)
+            val callback = function.apply(taskImplementation)
+            taskImplementation.callback = callback
             taskImplementation.asFuture().complete(taskImplementation)
         }
+    }
 
+    override fun <T : Any> runNow(function: Function<TaskImplementation<T>, T>): TaskImplementation<T> {
+        val taskImplementation = FoliaTask<T>()
+        val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = asyncScheduler.runNow(plugin, foliaConsumer)
         taskImplementation.scheduledTask = scheduledTask
         return taskImplementation
     }
 
-    override fun runDelayed(consumer: Consumer<TaskImplementation>, delay: Long, unit: TimeUnit): TaskImplementation {
-        val taskImplementation = FoliaTask()
-        val foliaConsumer: Consumer<ScheduledTask> = Consumer { scheduledTask ->
-            taskImplementation.scheduledTask = scheduledTask  // updating is probably not necessary
-            consumer.accept(taskImplementation)
-            taskImplementation.asFuture().complete(taskImplementation)
-        }
-
+    override fun <T : Any> runDelayed(
+        function: Function<TaskImplementation<T>, T>,
+        delay: Long,
+        unit: TimeUnit,
+    ): TaskImplementation<T> {
+        val taskImplementation = FoliaTask<T>()
+        val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = asyncScheduler.runDelayed(plugin, foliaConsumer, delay, unit)
         taskImplementation.scheduledTask = scheduledTask
         return taskImplementation
     }
 
-    override fun runAtFixedRate(
-        consumer: Consumer<TaskImplementation>,
+    override fun <T : Any> runAtFixedRate(
+        function: Function<TaskImplementation<T>, T>,
         delay: Long,
         period: Long,
-        unit: TimeUnit
-    ): TaskImplementation {
-        val taskImplementation = FoliaTask()
-        val foliaConsumer: Consumer<ScheduledTask> = Consumer { scheduledTask ->
-            taskImplementation.scheduledTask = scheduledTask  // updating is probably not necessary
-            consumer.accept(taskImplementation)
-            taskImplementation.asFuture().complete(taskImplementation)
-        }
-
+        unit: TimeUnit,
+    ): TaskImplementation<T> {
+        val taskImplementation = FoliaTask<T>()
+        val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = asyncScheduler.runAtFixedRate(plugin, foliaConsumer, delay, period, unit)
         taskImplementation.scheduledTask = scheduledTask
         return taskImplementation

--- a/platforms/folia/src/main/kotlin/com/cjcrafter/scheduler/folia/FoliaAsyncScheduler.kt
+++ b/platforms/folia/src/main/kotlin/com/cjcrafter/scheduler/folia/FoliaAsyncScheduler.kt
@@ -19,9 +19,9 @@ internal class FoliaAsyncScheduler(private val plugin: Plugin) : AsyncSchedulerI
         function: Function<TaskImplementation<T>, T>,
     ): Consumer<ScheduledTask> {
         return Consumer { scheduledTask ->
-            taskImplementation.scheduledTask = scheduledTask  // updating is probably not necessary
+            taskImplementation.setScheduledTask(scheduledTask)  // updating is probably not necessary
             val callback = function.apply(taskImplementation)
-            taskImplementation.callback = callback
+            taskImplementation.setCallback(callback)
             taskImplementation.asFuture().complete(taskImplementation)
         }
     }
@@ -30,7 +30,7 @@ internal class FoliaAsyncScheduler(private val plugin: Plugin) : AsyncSchedulerI
         val taskImplementation = FoliaTask<T>()
         val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = asyncScheduler.runNow(plugin, foliaConsumer)
-        taskImplementation.scheduledTask = scheduledTask
+        taskImplementation.setScheduledTask(scheduledTask)
         return taskImplementation
     }
 
@@ -42,7 +42,7 @@ internal class FoliaAsyncScheduler(private val plugin: Plugin) : AsyncSchedulerI
         val taskImplementation = FoliaTask<T>()
         val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = asyncScheduler.runDelayed(plugin, foliaConsumer, delay, unit)
-        taskImplementation.scheduledTask = scheduledTask
+        taskImplementation.setScheduledTask(scheduledTask)
         return taskImplementation
     }
 
@@ -55,7 +55,7 @@ internal class FoliaAsyncScheduler(private val plugin: Plugin) : AsyncSchedulerI
         val taskImplementation = FoliaTask<T>()
         val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = asyncScheduler.runAtFixedRate(plugin, foliaConsumer, delay, period, unit)
-        taskImplementation.scheduledTask = scheduledTask
+        taskImplementation.setScheduledTask(scheduledTask)
         return taskImplementation
     }
 }

--- a/platforms/folia/src/main/kotlin/com/cjcrafter/scheduler/folia/FoliaEntityScheduler.kt
+++ b/platforms/folia/src/main/kotlin/com/cjcrafter/scheduler/folia/FoliaEntityScheduler.kt
@@ -19,9 +19,9 @@ internal class FoliaEntityScheduler(private val plugin: Plugin, entity: Entity) 
         function: Function<TaskImplementation<T>, T>,
     ): Consumer<ScheduledTask> {
         return Consumer { scheduledTask ->
-            taskImplementation.scheduledTask = scheduledTask  // updating is probably not necessary
+            taskImplementation.setScheduledTask(scheduledTask)  // updating is probably not necessary
             val callback = function.apply(taskImplementation)
-            taskImplementation.callback = callback
+            taskImplementation.setCallback(callback)
             taskImplementation.asFuture().complete(taskImplementation)
         }
     }
@@ -37,7 +37,7 @@ internal class FoliaEntityScheduler(private val plugin: Plugin, entity: Entity) 
         val taskImplementation = FoliaTask<T>()
         val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = entityScheduler.run(plugin, foliaConsumer, retired) ?: return null
-        taskImplementation.scheduledTask = scheduledTask
+        taskImplementation.setScheduledTask(scheduledTask)
         return taskImplementation
     }
 
@@ -49,7 +49,7 @@ internal class FoliaEntityScheduler(private val plugin: Plugin, entity: Entity) 
         val taskImplementation = FoliaTask<T>()
         val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = entityScheduler.runDelayed(plugin, foliaConsumer, retired, delay) ?: return null
-        taskImplementation.scheduledTask = scheduledTask
+        taskImplementation.setScheduledTask(scheduledTask)
         return taskImplementation
     }
 
@@ -62,7 +62,7 @@ internal class FoliaEntityScheduler(private val plugin: Plugin, entity: Entity) 
         val taskImplementation = FoliaTask<T>()
         val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = entityScheduler.runAtFixedRate(plugin, foliaConsumer, retired, delay, period) ?: return null
-        taskImplementation.scheduledTask = scheduledTask
+        taskImplementation.setScheduledTask(scheduledTask)
         return taskImplementation
     }
 }

--- a/platforms/folia/src/main/kotlin/com/cjcrafter/scheduler/folia/FoliaEntityScheduler.kt
+++ b/platforms/folia/src/main/kotlin/com/cjcrafter/scheduler/folia/FoliaEntityScheduler.kt
@@ -7,59 +7,60 @@ import org.bukkit.entity.Entity
 import org.bukkit.plugin.Plugin
 import org.jetbrains.annotations.ApiStatus
 import java.util.function.Consumer
+import java.util.function.Function
 
 @ApiStatus.Internal
-class FoliaEntityScheduler(private val plugin: Plugin, entity: Entity) : EntitySchedulerImplementation {
+internal class FoliaEntityScheduler(private val plugin: Plugin, entity: Entity) : EntitySchedulerImplementation {
 
     private val entityScheduler = entity.scheduler
+
+    private fun <T : Any> buildFoliaConsumer(
+        taskImplementation: FoliaTask<T>,
+        function: Function<TaskImplementation<T>, T>,
+    ): Consumer<ScheduledTask> {
+        return Consumer { scheduledTask ->
+            taskImplementation.scheduledTask = scheduledTask  // updating is probably not necessary
+            val callback = function.apply(taskImplementation)
+            taskImplementation.callback = callback
+            taskImplementation.asFuture().complete(taskImplementation)
+        }
+    }
 
     override fun execute(run: Runnable, retired: Runnable?, delay: Long): Boolean {
         return entityScheduler.execute(plugin, run, retired, delay)
     }
 
-    override fun run(consumer: Consumer<TaskImplementation>, retired: Runnable?): TaskImplementation? {
-        val taskImplementation = FoliaTask()
-        val foliaConsumer: Consumer<ScheduledTask> = Consumer { scheduledTask ->
-            taskImplementation.scheduledTask = scheduledTask  // updating is probably not necessary
-            consumer.accept(taskImplementation)
-            taskImplementation.asFuture().complete(taskImplementation)
-        }
-
+    override fun <T : Any> run(
+        function: Function<TaskImplementation<T>, T>,
+        retired: Runnable?,
+    ): TaskImplementation<T>? {
+        val taskImplementation = FoliaTask<T>()
+        val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = entityScheduler.run(plugin, foliaConsumer, retired) ?: return null
         taskImplementation.scheduledTask = scheduledTask
         return taskImplementation
     }
 
-    override fun runDelayed(
-        consumer: Consumer<TaskImplementation>,
+    override fun <T : Any> runDelayed(
+        function: Function<TaskImplementation<T>, T>,
         retired: Runnable?,
-        delay: Long
-    ): TaskImplementation? {
-        val taskImplementation = FoliaTask()
-        val foliaConsumer: Consumer<ScheduledTask> = Consumer { task ->
-            taskImplementation.scheduledTask = task  // updating is probably not necessary
-            consumer.accept(taskImplementation)
-            taskImplementation.asFuture().complete(taskImplementation)
-        }
-
+        delay: Long,
+    ): TaskImplementation<T>? {
+        val taskImplementation = FoliaTask<T>()
+        val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = entityScheduler.runDelayed(plugin, foliaConsumer, retired, delay) ?: return null
         taskImplementation.scheduledTask = scheduledTask
         return taskImplementation
     }
 
-    override fun runAtFixedRate(
-        consumer: Consumer<TaskImplementation>,
+    override fun <T : Any> runAtFixedRate(
+        function: Function<TaskImplementation<T>, T>,
         retired: Runnable?,
         delay: Long,
         period: Long
-    ): TaskImplementation? {
-        val taskImplementation = FoliaTask()
-        val foliaConsumer: Consumer<ScheduledTask> = Consumer { task ->
-            taskImplementation.scheduledTask = task  // updating is probably not necessary
-            consumer.accept(taskImplementation)
-            taskImplementation.asFuture().complete(taskImplementation)
-        }
-
+    ): TaskImplementation<T>? {
+        val taskImplementation = FoliaTask<T>()
+        val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = entityScheduler.runAtFixedRate(plugin, foliaConsumer, retired, delay, period) ?: return null
         taskImplementation.scheduledTask = scheduledTask
         return taskImplementation

--- a/platforms/folia/src/main/kotlin/com/cjcrafter/scheduler/folia/FoliaGlobalScheduler.kt
+++ b/platforms/folia/src/main/kotlin/com/cjcrafter/scheduler/folia/FoliaGlobalScheduler.kt
@@ -6,50 +6,55 @@ import io.papermc.paper.threadedregions.scheduler.ScheduledTask
 import org.bukkit.plugin.Plugin
 import org.jetbrains.annotations.ApiStatus
 import java.util.function.Consumer
+import java.util.function.Function
 
 @ApiStatus.Internal
 internal class FoliaGlobalScheduler(private val plugin: Plugin) : SchedulerImplementation {
 
     private val globalRegionScheduler = plugin.server.globalRegionScheduler
 
+    private fun <T : Any> buildFoliaConsumer(
+        taskImplementation: FoliaTask<T>,
+        function: Function<TaskImplementation<T>, T>,
+    ): Consumer<ScheduledTask> {
+        return Consumer { scheduledTask ->
+            taskImplementation.scheduledTask = scheduledTask  // updating is probably not necessary
+            val callback = function.apply(taskImplementation)
+            taskImplementation.callback = callback
+            taskImplementation.asFuture().complete(taskImplementation)
+        }
+    }
+
     override fun execute(run: Runnable) {
         globalRegionScheduler.execute(plugin, run)
     }
 
-    override fun run(consumer: Consumer<TaskImplementation>): TaskImplementation {
-        val taskImplementation = FoliaTask()
-        val foliaConsumer: Consumer<ScheduledTask> = Consumer { scheduledTask ->
-            taskImplementation.scheduledTask = scheduledTask  // updating is probably not necessary
-            consumer.accept(taskImplementation)
-            taskImplementation.asFuture().complete(taskImplementation)
-        }
-
+    override fun <T : Any> run(function: Function<TaskImplementation<T>, T>): TaskImplementation<T> {
+        val taskImplementation = FoliaTask<T>()
+        val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = globalRegionScheduler.run(plugin, foliaConsumer)
         taskImplementation.scheduledTask = scheduledTask
         return taskImplementation
     }
 
-    override fun runDelayed(consumer: Consumer<TaskImplementation>, delay: Long): TaskImplementation {
-        val taskImplementation = FoliaTask()
-        val foliaConsumer: Consumer<ScheduledTask> = Consumer { scheduledTask ->
-            taskImplementation.scheduledTask = scheduledTask  // updating is probably not necessary
-            consumer.accept(taskImplementation)
-            taskImplementation.asFuture().complete(taskImplementation)
-        }
-
+    override fun <T : Any> runDelayed(
+        function: Function<TaskImplementation<T>, T>,
+        delay: Long,
+    ): TaskImplementation<T> {
+        val taskImplementation = FoliaTask<T>()
+        val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = globalRegionScheduler.runDelayed(plugin, foliaConsumer, delay)
         taskImplementation.scheduledTask = scheduledTask
         return taskImplementation
     }
 
-    override fun runAtFixedRate(consumer: Consumer<TaskImplementation>, delay: Long, period: Long): TaskImplementation {
-        val taskImplementation = FoliaTask()
-        val foliaConsumer: Consumer<ScheduledTask> = Consumer { scheduledTask ->
-            taskImplementation.scheduledTask = scheduledTask  // updating is probably not necessary
-            consumer.accept(taskImplementation)
-            taskImplementation.asFuture().complete(taskImplementation)
-        }
-
+    override fun <T : Any> runAtFixedRate(
+        function: Function<TaskImplementation<T>, T>,
+        delay: Long,
+        period: Long,
+    ): TaskImplementation<T> {
+        val taskImplementation = FoliaTask<T>()
+        val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = globalRegionScheduler.runAtFixedRate(plugin, foliaConsumer, delay, period)
         taskImplementation.scheduledTask = scheduledTask
         return taskImplementation

--- a/platforms/folia/src/main/kotlin/com/cjcrafter/scheduler/folia/FoliaGlobalScheduler.kt
+++ b/platforms/folia/src/main/kotlin/com/cjcrafter/scheduler/folia/FoliaGlobalScheduler.kt
@@ -18,9 +18,9 @@ internal class FoliaGlobalScheduler(private val plugin: Plugin) : SchedulerImple
         function: Function<TaskImplementation<T>, T>,
     ): Consumer<ScheduledTask> {
         return Consumer { scheduledTask ->
-            taskImplementation.scheduledTask = scheduledTask  // updating is probably not necessary
+            taskImplementation.setScheduledTask(scheduledTask)  // updating is probably not necessary
             val callback = function.apply(taskImplementation)
-            taskImplementation.callback = callback
+            taskImplementation.setCallback(callback)
             taskImplementation.asFuture().complete(taskImplementation)
         }
     }
@@ -33,7 +33,7 @@ internal class FoliaGlobalScheduler(private val plugin: Plugin) : SchedulerImple
         val taskImplementation = FoliaTask<T>()
         val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = globalRegionScheduler.run(plugin, foliaConsumer)
-        taskImplementation.scheduledTask = scheduledTask
+        taskImplementation.setScheduledTask(scheduledTask)
         return taskImplementation
     }
 
@@ -44,7 +44,7 @@ internal class FoliaGlobalScheduler(private val plugin: Plugin) : SchedulerImple
         val taskImplementation = FoliaTask<T>()
         val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = globalRegionScheduler.runDelayed(plugin, foliaConsumer, delay)
-        taskImplementation.scheduledTask = scheduledTask
+        taskImplementation.setScheduledTask(scheduledTask)
         return taskImplementation
     }
 
@@ -56,7 +56,7 @@ internal class FoliaGlobalScheduler(private val plugin: Plugin) : SchedulerImple
         val taskImplementation = FoliaTask<T>()
         val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = globalRegionScheduler.runAtFixedRate(plugin, foliaConsumer, delay, period)
-        taskImplementation.scheduledTask = scheduledTask
+        taskImplementation.setScheduledTask(scheduledTask)
         return taskImplementation
     }
 }

--- a/platforms/folia/src/main/kotlin/com/cjcrafter/scheduler/folia/FoliaRegionScheduler.kt
+++ b/platforms/folia/src/main/kotlin/com/cjcrafter/scheduler/folia/FoliaRegionScheduler.kt
@@ -24,9 +24,9 @@ internal class FoliaRegionScheduler(
         function: Function<TaskImplementation<T>, T>,
     ): Consumer<ScheduledTask> {
         return Consumer { scheduledTask ->
-            taskImplementation.scheduledTask = scheduledTask  // updating is probably not necessary
+            taskImplementation.setScheduledTask(scheduledTask)  // updating is probably not necessary
             val callback = function.apply(taskImplementation)
-            taskImplementation.callback = callback
+            taskImplementation.setCallback(callback)
             taskImplementation.asFuture().complete(taskImplementation)
         }
     }
@@ -39,7 +39,7 @@ internal class FoliaRegionScheduler(
         val taskImplementation = FoliaTask<T>()
         val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = regionScheduler.run(plugin, world, chunkX, chunkZ, foliaConsumer)
-        taskImplementation.scheduledTask = scheduledTask
+        taskImplementation.setScheduledTask(scheduledTask)
         return taskImplementation
     }
 
@@ -50,7 +50,7 @@ internal class FoliaRegionScheduler(
         val taskImplementation = FoliaTask<T>()
         val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = regionScheduler.runDelayed(plugin, world, chunkX, chunkZ, foliaConsumer, delay)
-        taskImplementation.scheduledTask = scheduledTask
+        taskImplementation.setScheduledTask(scheduledTask)
         return taskImplementation
     }
 
@@ -62,7 +62,7 @@ internal class FoliaRegionScheduler(
         val taskImplementation = FoliaTask<T>()
         val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = regionScheduler.runAtFixedRate(plugin, world, chunkX, chunkZ, foliaConsumer, delay, period)
-        taskImplementation.scheduledTask = scheduledTask
+        taskImplementation.setScheduledTask(scheduledTask)
         return taskImplementation
     }
 }

--- a/platforms/folia/src/main/kotlin/com/cjcrafter/scheduler/folia/FoliaRegionScheduler.kt
+++ b/platforms/folia/src/main/kotlin/com/cjcrafter/scheduler/folia/FoliaRegionScheduler.kt
@@ -7,6 +7,7 @@ import org.bukkit.World
 import org.bukkit.plugin.Plugin
 import org.jetbrains.annotations.ApiStatus
 import java.util.function.Consumer
+import java.util.function.Function
 
 @ApiStatus.Internal
 internal class FoliaRegionScheduler(
@@ -18,44 +19,48 @@ internal class FoliaRegionScheduler(
 
     private val regionScheduler = plugin.server.regionScheduler
 
+    private fun <T : Any> buildFoliaConsumer(
+        taskImplementation: FoliaTask<T>,
+        function: Function<TaskImplementation<T>, T>,
+    ): Consumer<ScheduledTask> {
+        return Consumer { scheduledTask ->
+            taskImplementation.scheduledTask = scheduledTask  // updating is probably not necessary
+            val callback = function.apply(taskImplementation)
+            taskImplementation.callback = callback
+            taskImplementation.asFuture().complete(taskImplementation)
+        }
+    }
+
     override fun execute(run: Runnable) {
         regionScheduler.execute(plugin, world, chunkX, chunkZ, run)
     }
 
-    override fun run(consumer: Consumer<TaskImplementation>): TaskImplementation {
-        val taskImplementation = FoliaTask()
-        val foliaConsumer: Consumer<ScheduledTask> = Consumer { scheduledTask ->
-            taskImplementation.scheduledTask = scheduledTask  // updating is probably not necessary
-            consumer.accept(taskImplementation)
-            taskImplementation.asFuture().complete(taskImplementation)
-        }
-
+    override fun <T : Any> run(function: Function<TaskImplementation<T>, T>): TaskImplementation<T> {
+        val taskImplementation = FoliaTask<T>()
+        val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = regionScheduler.run(plugin, world, chunkX, chunkZ, foliaConsumer)
         taskImplementation.scheduledTask = scheduledTask
         return taskImplementation
     }
 
-    override fun runDelayed(consumer: Consumer<TaskImplementation>, delay: Long): TaskImplementation {
-        val taskImplementation = FoliaTask()
-        val foliaConsumer: Consumer<ScheduledTask> = Consumer { scheduledTask ->
-            taskImplementation.scheduledTask = scheduledTask  // updating is probably not necessary
-            consumer.accept(taskImplementation)
-            taskImplementation.asFuture().complete(taskImplementation)
-        }
-
+    override fun <T : Any> runDelayed(
+        function: Function<TaskImplementation<T>, T>,
+        delay: Long,
+    ): TaskImplementation<T> {
+        val taskImplementation = FoliaTask<T>()
+        val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = regionScheduler.runDelayed(plugin, world, chunkX, chunkZ, foliaConsumer, delay)
         taskImplementation.scheduledTask = scheduledTask
         return taskImplementation
     }
 
-    override fun runAtFixedRate(consumer: Consumer<TaskImplementation>, delay: Long, period: Long): TaskImplementation {
-        val taskImplementation = FoliaTask()
-        val foliaConsumer: Consumer<ScheduledTask> = Consumer { scheduledTask ->
-            taskImplementation.scheduledTask = scheduledTask  // updating is probably not necessary
-            consumer.accept(taskImplementation)
-            taskImplementation.asFuture().complete(taskImplementation)
-        }
-
+    override fun <T : Any> runAtFixedRate(
+        function: Function<TaskImplementation<T>, T>,
+        delay: Long,
+        period: Long,
+    ): TaskImplementation<T> {
+        val taskImplementation = FoliaTask<T>()
+        val foliaConsumer = buildFoliaConsumer(taskImplementation, function)
         val scheduledTask = regionScheduler.runAtFixedRate(plugin, world, chunkX, chunkZ, foliaConsumer, delay, period)
         taskImplementation.scheduledTask = scheduledTask
         return taskImplementation

--- a/platforms/folia/src/main/kotlin/com/cjcrafter/scheduler/folia/FoliaTask.kt
+++ b/platforms/folia/src/main/kotlin/com/cjcrafter/scheduler/folia/FoliaTask.kt
@@ -3,12 +3,14 @@ package com.cjcrafter.scheduler.folia
 import com.cjcrafter.scheduler.TaskImplementation
 import io.papermc.paper.threadedregions.scheduler.ScheduledTask
 import org.bukkit.plugin.Plugin
+import java.util.*
 import java.util.concurrent.CompletableFuture
 
-class FoliaTask : TaskImplementation {
+class FoliaTask<T : Any> : TaskImplementation<T> {
 
     lateinit var scheduledTask: ScheduledTask
-    private val future: CompletableFuture<TaskImplementation> = CompletableFuture()
+    private val future: CompletableFuture<TaskImplementation<T>> = CompletableFuture()
+    internal var callback: T? = null
 
     override val owningPlugin: Plugin
         get() = scheduledTask.owningPlugin
@@ -30,7 +32,11 @@ class FoliaTask : TaskImplementation {
         return scheduledTask.isRepeatingTask
     }
 
-    override fun asFuture(): CompletableFuture<TaskImplementation> {
+    override fun getCallback(): T? {
+        return callback
+    }
+
+    override fun asFuture(): CompletableFuture<TaskImplementation<T>> {
         return future
     }
 }

--- a/platforms/folia/src/main/kotlin/com/cjcrafter/scheduler/folia/FoliaTask.kt
+++ b/platforms/folia/src/main/kotlin/com/cjcrafter/scheduler/folia/FoliaTask.kt
@@ -3,37 +3,52 @@ package com.cjcrafter.scheduler.folia
 import com.cjcrafter.scheduler.TaskImplementation
 import io.papermc.paper.threadedregions.scheduler.ScheduledTask
 import org.bukkit.plugin.Plugin
+import org.jetbrains.annotations.ApiStatus
 import java.util.*
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 class FoliaTask<T : Any> : TaskImplementation<T> {
 
-    lateinit var scheduledTask: ScheduledTask
+    private val lock = ReentrantLock()
+    private val scheduledTaskRef = AtomicReference<ScheduledTask>()
     private val future: CompletableFuture<TaskImplementation<T>> = CompletableFuture()
-    internal var callback: T? = null
+    private var callback: T? = null
 
     override val owningPlugin: Plugin
-        get() = scheduledTask.owningPlugin
+        get() = scheduledTaskRef.get().owningPlugin
+
+    @ApiStatus.Internal
+    fun setScheduledTask(scheduledTask: ScheduledTask) {
+        scheduledTaskRef.set(scheduledTask)
+    }
 
     override fun cancel() {
-        scheduledTask.cancel()
+        scheduledTaskRef.get().cancel()
     }
 
     override fun isCancelled(): Boolean {
-        return scheduledTask.isCancelled
+        return scheduledTaskRef.get().isCancelled
     }
 
     override fun isRunning(): Boolean {
-        return scheduledTask.executionState == ScheduledTask.ExecutionState.RUNNING
-                || scheduledTask.executionState == ScheduledTask.ExecutionState.CANCELLED_RUNNING
+        return scheduledTaskRef.get().executionState == ScheduledTask.ExecutionState.RUNNING
+                || scheduledTaskRef.get().executionState == ScheduledTask.ExecutionState.CANCELLED_RUNNING
     }
 
     override fun isRepeatingTask(): Boolean {
-        return scheduledTask.isRepeatingTask
+        return scheduledTaskRef.get().isRepeatingTask
     }
 
     override fun getCallback(): T? {
-        return callback
+        return lock.withLock { callback }
+    }
+
+    @ApiStatus.Internal
+    fun setCallback(callback: T?) {
+        lock.withLock { this.callback = callback }
     }
 
     override fun asFuture(): CompletableFuture<TaskImplementation<T>> {

--- a/platforms/spigot/build.gradle.kts
+++ b/platforms/spigot/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     // 1.12.2 is the oldest version we plan on officially supporting
     compileOnly(project(":"))
     compileOnly("org.spigotmc:spigot-api:1.12.2-R0.1-SNAPSHOT")
+    compileOnly("org.jetbrains:annotations:24.1.0")
 }
 
 kotlin {

--- a/platforms/spigot/src/main/kotlin/com/cjcrafter/scheduler/bukkit/BukkitAsyncScheduler.kt
+++ b/platforms/spigot/src/main/kotlin/com/cjcrafter/scheduler/bukkit/BukkitAsyncScheduler.kt
@@ -4,15 +4,19 @@ import com.cjcrafter.scheduler.AsyncSchedulerImplementation
 import com.cjcrafter.scheduler.TaskImplementation
 import org.bukkit.plugin.Plugin
 import org.bukkit.scheduler.BukkitRunnable
+import org.jetbrains.annotations.ApiStatus
 import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
+import java.util.function.Function
 
-class BukkitAsyncScheduler(private val plugin: Plugin) : AsyncSchedulerImplementation {
-    override fun runNow(consumer: Consumer<TaskImplementation>): TaskImplementation {
-        val taskImplementation = BukkitTask(plugin, false)
+@ApiStatus.Internal
+internal class BukkitAsyncScheduler(private val plugin: Plugin) : AsyncSchedulerImplementation {
+    override fun <T : Any> runNow(function: Function<TaskImplementation<T>, T>): TaskImplementation<T> {
+        val taskImplementation = BukkitTask<T>(plugin, false)
         val scheduledTask = object : BukkitRunnable() {
             override fun run() {
-                consumer.accept(taskImplementation)
+                val callback = function.apply(taskImplementation)
+                taskImplementation.callback = callback
                 taskImplementation.asFuture().complete(taskImplementation)
             }
         }.runTaskAsynchronously(plugin)
@@ -21,11 +25,16 @@ class BukkitAsyncScheduler(private val plugin: Plugin) : AsyncSchedulerImplement
         return taskImplementation
     }
 
-    override fun runDelayed(consumer: Consumer<TaskImplementation>, delay: Long, unit: TimeUnit): TaskImplementation {
-        val taskImplementation = BukkitTask(plugin, false)
+    override fun <T : Any> runDelayed(
+        function: Function<TaskImplementation<T>, T>,
+        delay: Long,
+        unit: TimeUnit,
+    ): TaskImplementation<T> {
+        val taskImplementation = BukkitTask<T>(plugin, false)
         val scheduledTask = object : BukkitRunnable() {
             override fun run() {
-                consumer.accept(taskImplementation)
+                val callback = function.apply(taskImplementation)
+                taskImplementation.callback = callback
                 taskImplementation.asFuture().complete(taskImplementation)
             }
         }.runTaskLaterAsynchronously(plugin, unit.toMillis(delay) / 50)
@@ -34,16 +43,17 @@ class BukkitAsyncScheduler(private val plugin: Plugin) : AsyncSchedulerImplement
         return taskImplementation
     }
 
-    override fun runAtFixedRate(
-        consumer: Consumer<TaskImplementation>,
+    override fun <T : Any> runAtFixedRate(
+        function: Function<TaskImplementation<T>, T>,
         delay: Long,
         period: Long,
         unit: TimeUnit
-    ): TaskImplementation {
-        val taskImplementation = BukkitTask(plugin, true)
+    ): TaskImplementation<T> {
+        val taskImplementation = BukkitTask<T>(plugin, true)
         val scheduledTask = object : BukkitRunnable() {
             override fun run() {
-                consumer.accept(taskImplementation)
+                val callback = function.apply(taskImplementation)
+                taskImplementation.callback = callback
                 taskImplementation.asFuture().complete(taskImplementation)
             }
         }.runTaskTimerAsynchronously(plugin, unit.toMillis(delay) / 50, unit.toMillis(period) / 50)
@@ -51,6 +61,4 @@ class BukkitAsyncScheduler(private val plugin: Plugin) : AsyncSchedulerImplement
         taskImplementation.scheduledTask = scheduledTask
         return taskImplementation
     }
-
-
 }

--- a/platforms/spigot/src/main/kotlin/com/cjcrafter/scheduler/bukkit/BukkitAsyncScheduler.kt
+++ b/platforms/spigot/src/main/kotlin/com/cjcrafter/scheduler/bukkit/BukkitAsyncScheduler.kt
@@ -16,12 +16,12 @@ internal class BukkitAsyncScheduler(private val plugin: Plugin) : AsyncScheduler
         val scheduledTask = object : BukkitRunnable() {
             override fun run() {
                 val callback = function.apply(taskImplementation)
-                taskImplementation.callback = callback
+                taskImplementation.setCallback(callback)
                 taskImplementation.asFuture().complete(taskImplementation)
             }
         }.runTaskAsynchronously(plugin)
 
-        taskImplementation.scheduledTask = scheduledTask
+        taskImplementation.setScheduledTask(scheduledTask)
         return taskImplementation
     }
 
@@ -34,12 +34,12 @@ internal class BukkitAsyncScheduler(private val plugin: Plugin) : AsyncScheduler
         val scheduledTask = object : BukkitRunnable() {
             override fun run() {
                 val callback = function.apply(taskImplementation)
-                taskImplementation.callback = callback
+                taskImplementation.setCallback(callback)
                 taskImplementation.asFuture().complete(taskImplementation)
             }
         }.runTaskLaterAsynchronously(plugin, unit.toMillis(delay) / 50)
 
-        taskImplementation.scheduledTask = scheduledTask
+        taskImplementation.setScheduledTask(scheduledTask)
         return taskImplementation
     }
 
@@ -53,12 +53,12 @@ internal class BukkitAsyncScheduler(private val plugin: Plugin) : AsyncScheduler
         val scheduledTask = object : BukkitRunnable() {
             override fun run() {
                 val callback = function.apply(taskImplementation)
-                taskImplementation.callback = callback
+                taskImplementation.setCallback(callback)
                 taskImplementation.asFuture().complete(taskImplementation)
             }
         }.runTaskTimerAsynchronously(plugin, unit.toMillis(delay) / 50, unit.toMillis(period) / 50)
 
-        taskImplementation.scheduledTask = scheduledTask
+        taskImplementation.setScheduledTask(scheduledTask)
         return taskImplementation
     }
 }

--- a/platforms/spigot/src/main/kotlin/com/cjcrafter/scheduler/bukkit/BukkitEntityScheduler.kt
+++ b/platforms/spigot/src/main/kotlin/com/cjcrafter/scheduler/bukkit/BukkitEntityScheduler.kt
@@ -49,12 +49,12 @@ internal class BukkitEntityScheduler(
                     return
                 }
                 val callback = function.apply(taskImplementation)
-                taskImplementation.callback = callback
+                taskImplementation.setCallback(callback)
                 taskImplementation.asFuture().complete(taskImplementation)
             }
         }.runTask(plugin)
 
-        taskImplementation.scheduledTask = scheduledTask
+        taskImplementation.setScheduledTask(scheduledTask)
         return taskImplementation
     }
 
@@ -76,12 +76,12 @@ internal class BukkitEntityScheduler(
                     return
                 }
                 val callback = function.apply(taskImplementation)
-                taskImplementation.callback = callback
+                taskImplementation.setCallback(callback)
                 taskImplementation.asFuture().complete(taskImplementation)
             }
         }.runTaskLater(plugin, delay)
 
-        taskImplementation.scheduledTask = scheduledTask
+        taskImplementation.setScheduledTask(scheduledTask)
         return taskImplementation
     }
 
@@ -104,12 +104,12 @@ internal class BukkitEntityScheduler(
                     return
                 }
                 val callback = function.apply(taskImplementation)
-                taskImplementation.callback = callback
+                taskImplementation.setCallback(callback)
                 taskImplementation.asFuture().complete(taskImplementation)
             }
         }.runTaskTimer(plugin, delay, period)
 
-        taskImplementation.scheduledTask = scheduledTask
+        taskImplementation.setScheduledTask(scheduledTask)
         return taskImplementation
     }
 }

--- a/platforms/spigot/src/main/kotlin/com/cjcrafter/scheduler/bukkit/BukkitSyncScheduler.kt
+++ b/platforms/spigot/src/main/kotlin/com/cjcrafter/scheduler/bukkit/BukkitSyncScheduler.kt
@@ -4,9 +4,12 @@ import com.cjcrafter.scheduler.SchedulerImplementation
 import com.cjcrafter.scheduler.TaskImplementation
 import org.bukkit.plugin.Plugin
 import org.bukkit.scheduler.BukkitRunnable
+import org.jetbrains.annotations.ApiStatus
 import java.util.function.Consumer
+import java.util.function.Function
 
-class BukkitSyncScheduler(private val plugin: Plugin) : SchedulerImplementation {
+@ApiStatus.Internal
+internal class BukkitSyncScheduler(private val plugin: Plugin) : SchedulerImplementation {
     override fun execute(run: Runnable) {
         object : BukkitRunnable() {
             override fun run() {
@@ -15,11 +18,12 @@ class BukkitSyncScheduler(private val plugin: Plugin) : SchedulerImplementation 
         }.runTask(plugin)
     }
 
-    override fun run(consumer: Consumer<TaskImplementation>): TaskImplementation {
-        val taskImplementation = BukkitTask(plugin, false)
+    override fun <T : Any> run(function: Function<TaskImplementation<T>, T>): TaskImplementation<T> {
+        val taskImplementation = BukkitTask<T>(plugin, false)
         val scheduledTask = object : BukkitRunnable() {
             override fun run() {
-                consumer.accept(taskImplementation)
+                val callback = function.apply(taskImplementation)
+                taskImplementation.callback = callback
                 taskImplementation.asFuture().complete(taskImplementation)
             }
         }.runTask(plugin)
@@ -28,11 +32,15 @@ class BukkitSyncScheduler(private val plugin: Plugin) : SchedulerImplementation 
         return taskImplementation
     }
 
-    override fun runDelayed(consumer: Consumer<TaskImplementation>, delay: Long): TaskImplementation {
-        val taskImplementation = BukkitTask(plugin, false)
+    override fun <T : Any> runDelayed(
+        function: Function<TaskImplementation<T>, T>,
+        delay: Long,
+    ): TaskImplementation<T> {
+        val taskImplementation = BukkitTask<T>(plugin, false)
         val scheduledTask = object : BukkitRunnable() {
             override fun run() {
-                consumer.accept(taskImplementation)
+                val callback = function.apply(taskImplementation)
+                taskImplementation.callback = callback
                 taskImplementation.asFuture().complete(taskImplementation)
             }
         }.runTaskLater(plugin, delay)
@@ -41,11 +49,16 @@ class BukkitSyncScheduler(private val plugin: Plugin) : SchedulerImplementation 
         return taskImplementation
     }
 
-    override fun runAtFixedRate(consumer: Consumer<TaskImplementation>, delay: Long, period: Long): TaskImplementation {
-        val taskImplementation = BukkitTask(plugin, true)
+    override fun <T : Any> runAtFixedRate(
+        function: Function<TaskImplementation<T>, T>,
+        delay: Long,
+        period: Long,
+    ): TaskImplementation<T> {
+        val taskImplementation = BukkitTask<T>(plugin, true)
         val scheduledTask = object : BukkitRunnable() {
             override fun run() {
-                consumer.accept(taskImplementation)
+                val callback = function.apply(taskImplementation)
+                taskImplementation.callback = callback
                 taskImplementation.asFuture().complete(taskImplementation)
             }
         }.runTaskTimer(plugin, delay, period)

--- a/platforms/spigot/src/main/kotlin/com/cjcrafter/scheduler/bukkit/BukkitSyncScheduler.kt
+++ b/platforms/spigot/src/main/kotlin/com/cjcrafter/scheduler/bukkit/BukkitSyncScheduler.kt
@@ -23,12 +23,12 @@ internal class BukkitSyncScheduler(private val plugin: Plugin) : SchedulerImplem
         val scheduledTask = object : BukkitRunnable() {
             override fun run() {
                 val callback = function.apply(taskImplementation)
-                taskImplementation.callback = callback
+                taskImplementation.setCallback(callback)
                 taskImplementation.asFuture().complete(taskImplementation)
             }
         }.runTask(plugin)
 
-        taskImplementation.scheduledTask = scheduledTask
+        taskImplementation.setScheduledTask(scheduledTask)
         return taskImplementation
     }
 
@@ -40,12 +40,12 @@ internal class BukkitSyncScheduler(private val plugin: Plugin) : SchedulerImplem
         val scheduledTask = object : BukkitRunnable() {
             override fun run() {
                 val callback = function.apply(taskImplementation)
-                taskImplementation.callback = callback
+                taskImplementation.setCallback(callback)
                 taskImplementation.asFuture().complete(taskImplementation)
             }
         }.runTaskLater(plugin, delay)
 
-        taskImplementation.scheduledTask = scheduledTask
+        taskImplementation.setScheduledTask(scheduledTask)
         return taskImplementation
     }
 
@@ -58,12 +58,12 @@ internal class BukkitSyncScheduler(private val plugin: Plugin) : SchedulerImplem
         val scheduledTask = object : BukkitRunnable() {
             override fun run() {
                 val callback = function.apply(taskImplementation)
-                taskImplementation.callback = callback
+                taskImplementation.setCallback(callback)
                 taskImplementation.asFuture().complete(taskImplementation)
             }
         }.runTaskTimer(plugin, delay, period)
 
-        taskImplementation.scheduledTask = scheduledTask
+        taskImplementation.setScheduledTask(scheduledTask)
         return taskImplementation
     }
 }

--- a/platforms/spigot/src/main/kotlin/com/cjcrafter/scheduler/bukkit/BukkitTask.kt
+++ b/platforms/spigot/src/main/kotlin/com/cjcrafter/scheduler/bukkit/BukkitTask.kt
@@ -2,27 +2,38 @@ package com.cjcrafter.scheduler.bukkit
 
 import com.cjcrafter.scheduler.TaskImplementation
 import org.bukkit.plugin.Plugin
+import org.bukkit.scheduler.BukkitTask
+import org.jetbrains.annotations.ApiStatus
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 class BukkitTask<T : Any>(
     override val owningPlugin: Plugin,
     private val isRepeatingTask: Boolean,
 ) : TaskImplementation<T> {
 
-    lateinit var scheduledTask: org.bukkit.scheduler.BukkitTask
+    private val lock = ReentrantLock()
+    private val scheduledTaskRef = AtomicReference<BukkitTask>()
     private val future: CompletableFuture<TaskImplementation<T>> = CompletableFuture()
-    internal var callback: T? = null
+    private var callback: T? = null
+
+    @ApiStatus.Internal
+    fun setScheduledTask(scheduledTask: BukkitTask) {
+        scheduledTaskRef.set(scheduledTask)
+    }
 
     override fun cancel() {
-        scheduledTask.cancel()
+        scheduledTaskRef.get().cancel()
     }
 
     override fun isCancelled(): Boolean {
-        return scheduledTask.isCancelled
+        return scheduledTaskRef.get().isCancelled
     }
 
     override fun isRunning(): Boolean {
-        return owningPlugin.server.scheduler.isCurrentlyRunning(scheduledTask.taskId)
+        return owningPlugin.server.scheduler.isCurrentlyRunning(scheduledTaskRef.get().taskId)
     }
 
     override fun isRepeatingTask(): Boolean {
@@ -30,7 +41,11 @@ class BukkitTask<T : Any>(
     }
 
     override fun getCallback(): T? {
-        return callback
+        return lock.withLock { callback }
+    }
+
+    fun setCallback(callback: T?) {
+        lock.withLock { this.callback = callback }
     }
 
     override fun asFuture(): CompletableFuture<TaskImplementation<T>> {

--- a/platforms/spigot/src/main/kotlin/com/cjcrafter/scheduler/bukkit/BukkitTask.kt
+++ b/platforms/spigot/src/main/kotlin/com/cjcrafter/scheduler/bukkit/BukkitTask.kt
@@ -4,13 +4,14 @@ import com.cjcrafter.scheduler.TaskImplementation
 import org.bukkit.plugin.Plugin
 import java.util.concurrent.CompletableFuture
 
-class BukkitTask(
+class BukkitTask<T : Any>(
     override val owningPlugin: Plugin,
     private val isRepeatingTask: Boolean,
-) : TaskImplementation {
+) : TaskImplementation<T> {
 
     lateinit var scheduledTask: org.bukkit.scheduler.BukkitTask
-    private val future: CompletableFuture<TaskImplementation> = CompletableFuture()
+    private val future: CompletableFuture<TaskImplementation<T>> = CompletableFuture()
+    internal var callback: T? = null
 
     override fun cancel() {
         scheduledTask.cancel()
@@ -28,7 +29,11 @@ class BukkitTask(
         return isRepeatingTask
     }
 
-    override fun asFuture(): CompletableFuture<TaskImplementation> {
+    override fun getCallback(): T? {
+        return callback
+    }
+
+    override fun asFuture(): CompletableFuture<TaskImplementation<T>> {
         return future
     }
 }

--- a/src/main/kotlin/com/cjcrafter/scheduler/AsyncSchedulerImplementation.kt
+++ b/src/main/kotlin/com/cjcrafter/scheduler/AsyncSchedulerImplementation.kt
@@ -2,15 +2,45 @@ package com.cjcrafter.scheduler
 
 import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
+import java.util.function.Function
 
 /**
  * Represents a scheduler that can schedule tasks to be run asynchronously (separate from the server thread(s)).
  */
 interface AsyncSchedulerImplementation {
+
     /**
      * Runs a task asynchronously immediately.
      */
-    fun runNow(consumer: Consumer<TaskImplementation>): TaskImplementation
+    fun <T : Any> runNow(function: Function<TaskImplementation<T>, T>): TaskImplementation<T>
+
+    /**
+     * Runs a task asynchronously immediately.
+     */
+    fun <T : Any> runNow(consumer: Consumer<TaskImplementation<Void>>): TaskImplementation<Void> {
+        val wrapperFunction = Function<TaskImplementation<Void>, Void> { task ->
+            consumer.accept(task)
+            null
+        }
+        return this.runNow(wrapperFunction)
+    }
+
+    /**
+     * Runs a task asynchronously immediately.
+     */
+    fun runNow(runnable: Runnable): TaskImplementation<Void> {
+        val wrapperFunction = Function<TaskImplementation<Void>, Void> { task ->
+            runnable.run()
+            null
+        }
+        return this.runNow(wrapperFunction)
+    }
+
+    fun <T : Any> runDelayed(
+        function: Function<TaskImplementation<T>, T>,
+        delay: Long,
+        unit: TimeUnit,
+    ): TaskImplementation<T>
 
     /**
      * Schedules a task to be run asynchronously after a delay.
@@ -21,25 +51,97 @@ interface AsyncSchedulerImplementation {
      * @return The task that was scheduled.
      */
     fun runDelayed(
-        consumer: Consumer<TaskImplementation>,
+        consumer: Consumer<TaskImplementation<Void>>,
         delay: Long,
-        unit: TimeUnit
-    ): TaskImplementation
+        unit: TimeUnit,
+    ): TaskImplementation<Void> {
+        val wrapperFunction = Function<TaskImplementation<Void>, Void> { task ->
+            consumer.accept(task)
+            null
+        }
+        return this.runDelayed(wrapperFunction, delay, unit)
+    }
+
+    /**
+     * Schedules a task to be run asynchronously after a delay.
+     *
+     * @param runnable The task to run.
+     * @param delay The delay before the task is run.
+     * @param unit The time unit of the delay.
+     * @return The task that was scheduled.
+     */
+    fun runDelayed(
+        runnable: Runnable,
+        delay: Long,
+        unit: TimeUnit,
+    ): TaskImplementation<Void> {
+        val wrapperFunction = Function<TaskImplementation<Void>, Void> { task ->
+            runnable.run()
+            null
+        }
+        return this.runDelayed(wrapperFunction, delay, unit)
+    }
+
+    /**
+     * Schedules a task to be run asynchronously after a delay, in ticks.
+     *
+     * @param function The task to run.
+     * @param ticks The delay in ticks before the task is run.
+     * @return The task that was scheduled.
+     */
+    fun <T : Any> runDelayed(
+        function: Function<TaskImplementation<T>, T>,
+        ticks: Long,
+    ): TaskImplementation<T> {
+        // assumes the time unit is server ticks. Since 20 ticks = 1000ms, we can convert the delay to milliseconds
+        return runDelayed(function, ticks * 50, TimeUnit.MILLISECONDS)
+    }
 
     /**
      * Schedules a task to be run asynchronously after a delay, in ticks.
      *
      * @param consumer The task to run.
-     * @param delay The delay in ticks before the task is run.
+     * @param ticks The delay in ticks before the task is run.
      * @return The task that was scheduled.
      */
     fun runDelayed(
-        consumer: Consumer<TaskImplementation>,
-        delay: Long
-    ): TaskImplementation {
+        consumer: Consumer<TaskImplementation<Void>>,
+        ticks: Long,
+    ): TaskImplementation<Void> {
         // assumes the time unit is server ticks. Since 20 ticks = 1000ms, we can convert the delay to milliseconds
-        return runDelayed(consumer, delay * 50, TimeUnit.MILLISECONDS)
+        return runDelayed(consumer, ticks * 50, TimeUnit.MILLISECONDS)
     }
+
+    /**
+     * Schedules a task to be run asynchronously after a delay, in ticks.
+     *
+     * @param runnable The task to run.
+     * @param ticks The delay in ticks before the task is run.
+     * @return The task that was scheduled.
+     */
+    fun runDelayed(
+        runnable: Runnable,
+        ticks: Long,
+    ): TaskImplementation<Void> {
+        // assumes the time unit is server ticks. Since 20 ticks = 1000ms, we can convert the delay to milliseconds
+        return runDelayed(runnable, ticks * 50, TimeUnit.MILLISECONDS)
+    }
+
+    /**
+     * Schedules a task to be run asynchronously after a delay and then repeatedly after a period.
+     *
+     * @param function The task to run.
+     * @param delay The delay before the task is run.
+     * @param period The period between each run.
+     * @param unit The time unit of the delay and period.
+     * @return The task that was scheduled.
+     */
+    fun <T : Any> runAtFixedRate(
+        function: Function<TaskImplementation<T>, T>,
+        delay: Long,
+        period: Long,
+        unit: TimeUnit,
+    ): TaskImplementation<T>
 
     /**
      * Schedules a task to be run asynchronously after a delay and then repeatedly after a period.
@@ -51,26 +153,88 @@ interface AsyncSchedulerImplementation {
      * @return The task that was scheduled.
      */
     fun runAtFixedRate(
-        consumer: Consumer<TaskImplementation>,
+        consumer: Consumer<TaskImplementation<Void>>,
         delay: Long,
         period: Long,
-        unit: TimeUnit
-    ): TaskImplementation
+        unit: TimeUnit,
+    ): TaskImplementation<Void> {
+        val wrapperFunction = Function<TaskImplementation<Void>, Void> { task ->
+            consumer.accept(task)
+            null
+        }
+        return this.runAtFixedRate(wrapperFunction, delay, period, unit)
+    }
+
+    /**
+     * Schedules a task to be run asynchronously after a delay and then repeatedly after a period.
+     *
+     * @param runnable The task to run.
+     * @param delay The delay before the task is run.
+     * @param period The period between each run.
+     * @param unit The time unit of the delay and period.
+     * @return The task that was scheduled.
+     */
+    fun runAtFixedRate(
+        runnable: Runnable,
+        delay: Long,
+        period: Long,
+        unit: TimeUnit,
+    ): TaskImplementation<Void> {
+        val wrapperFunction = Function<TaskImplementation<Void>, Void> { task ->
+            runnable.run()
+            null
+        }
+        return this.runAtFixedRate(wrapperFunction, delay, period, unit)
+    }
+
+    /**
+     * Schedules a task to be run asynchronously after a delay and then repeatedly after a period, in ticks.
+     *
+     * @param function The task to run.
+     * @param delay The delay in ticks before the task is run.
+     * @param ticks The period in ticks between each run.
+     * @return The task that was scheduled.
+     */
+    fun <T : Any> runAtFixedRate(
+        function: Function<TaskImplementation<T>, T>,
+        delay: Long,
+        ticks: Long,
+    ): TaskImplementation<T> {
+        // assumes the time unit is server ticks. Since 20 ticks = 1000ms, we can convert the delay to milliseconds
+        return runAtFixedRate(function, delay * 50, ticks * 50, TimeUnit.MILLISECONDS)
+    }
 
     /**
      * Schedules a task to be run asynchronously after a delay and then repeatedly after a period, in ticks.
      *
      * @param consumer The task to run.
      * @param delay The delay in ticks before the task is run.
-     * @param period The period in ticks between each run.
+     * @param ticks The period in ticks between each run.
      * @return The task that was scheduled.
      */
     fun runAtFixedRate(
-        consumer: Consumer<TaskImplementation>,
+        consumer: Consumer<TaskImplementation<Void>>,
         delay: Long,
-        period: Long
-    ): TaskImplementation {
+        ticks: Long,
+    ): TaskImplementation<Void> {
         // assumes the time unit is server ticks. Since 20 ticks = 1000ms, we can convert the delay to milliseconds
-        return runAtFixedRate(consumer, delay * 50, period * 50, TimeUnit.MILLISECONDS)
+        return runAtFixedRate(consumer, delay * 50, ticks * 50, TimeUnit.MILLISECONDS)
+    }
+
+    /**
+     * Schedules a task to be run asynchronously after a delay and then repeatedly after a period, in ticks.
+     *
+     * @param runnable The task to run.
+     * @param delay The delay in ticks before the task is run.
+     * @param ticks The period in ticks between each run.
+     * @return The task that was scheduled.
+     */
+    fun runAtFixedRate(
+        runnable: Runnable,
+        delay: Long,
+        ticks: Long,
+    ): TaskImplementation<Void> {
+        // assumes the time unit is server ticks. Since 20 ticks = 1000ms, we can convert the delay to milliseconds
+        return runAtFixedRate(runnable, delay * 50, ticks * 50, TimeUnit.MILLISECONDS)
     }
 }

--- a/src/main/kotlin/com/cjcrafter/scheduler/EntitySchedulerImplementation.kt
+++ b/src/main/kotlin/com/cjcrafter/scheduler/EntitySchedulerImplementation.kt
@@ -1,6 +1,7 @@
 package com.cjcrafter.scheduler
 
 import java.util.function.Consumer
+import java.util.function.Function
 
 /**
  * Represents a scheduler that can schedule tasks to be run on an entity.
@@ -32,11 +33,11 @@ interface EntitySchedulerImplementation {
     /**
      * Schedules a task to be run on the next tick.
      *
-     * @param consumer The task to run.
+     * @param function The task to run.
      * @param retired The task to run if the entity is retired.
      * @return The task that was scheduled.
      */
-    fun run(consumer: Consumer<TaskImplementation>, retired: Runnable?): TaskImplementation?
+    fun <T : Any> run(function: Function<TaskImplementation<T>, T>, retired: Runnable?): TaskImplementation<T>?
 
     /**
      * Schedules a task to be run on the next tick.
@@ -44,11 +45,73 @@ interface EntitySchedulerImplementation {
      * @param consumer The task to run.
      * @return The task that was scheduled.
      */
-    fun run(consumer: Consumer<TaskImplementation>): TaskImplementation? {
+    fun run(consumer: Consumer<TaskImplementation<Void>>, retired: Runnable?): TaskImplementation<Void>? {
+        val wrapperFunction = Function<TaskImplementation<Void>, Void> { task ->
+            consumer.accept(task)
+            null
+        }
+        return run(wrapperFunction, retired)
+    }
+
+    /**
+     * Schedules a task to be run on the next tick.
+     *
+     * @param runnable The task to run.
+     * @return The task that was scheduled.
+     */
+    fun run(runnable: Runnable, retired: Runnable?): TaskImplementation<Void>? {
+        val wrapperFunction = Function<TaskImplementation<Void>, Void> { task ->
+            runnable.run()
+            null
+        }
+        return run(wrapperFunction, retired)
+    }
+
+    /**
+     * Schedules a task to be run on the next tick.
+     *
+     * @param function The task to run.
+     * @return The task that was scheduled.
+     */
+    fun <T : Any> run(function: Function<TaskImplementation<T>, T>): TaskImplementation<T>? {
+        return run(function, null)
+    }
+
+    /**
+     * Schedules a task to be run on the next tick.
+     *
+     * @param consumer The task to run.
+     * @return The task that was scheduled.
+     */
+    fun run(consumer: Consumer<TaskImplementation<Void>>): TaskImplementation<Void>? {
         return run(consumer, null)
     }
 
     /**
+     * Schedules a task to be run on the next tick.
+     *
+     * @param runnable The task to run.
+     * @return The task that was scheduled.
+     */
+    fun run(runnable: Runnable): TaskImplementation<Void>? {
+        return run(runnable, null)
+    }
+
+    /**
+     * Schedules a task to be run after a delay.
+     *
+     * @param function The task to run.
+     * @param retired The task to run if the entity is retired.
+     * @param delay The delay before the task is run.
+     * @return The task that was scheduled.
+     */
+    fun <T : Any> runDelayed(
+        function: Function<TaskImplementation<T>, T>,
+        retired: Runnable?,
+        delay: Long,
+    ): TaskImplementation<T>?
+
+    /**
      * Schedules a task to be run after a delay.
      *
      * @param consumer The task to run.
@@ -56,7 +119,51 @@ interface EntitySchedulerImplementation {
      * @param delay The delay before the task is run.
      * @return The task that was scheduled.
      */
-    fun runDelayed(consumer: Consumer<TaskImplementation>, retired: Runnable?, delay: Long): TaskImplementation?
+    fun runDelayed(
+        consumer: Consumer<TaskImplementation<Void>>,
+        retired: Runnable?,
+        delay: Long,
+    ): TaskImplementation<Void>? {
+        val wrapperFunction = Function<TaskImplementation<Void>, Void> { task ->
+            consumer.accept(task)
+            null
+        }
+        return runDelayed(wrapperFunction, retired, delay)
+    }
+
+    /**
+     * Schedules a task to be run after a delay.
+     *
+     * @param runnable The task to run.
+     * @param retired The task to run if the entity is retired.
+     * @param delay The delay before the task is run.
+     * @return The task that was scheduled.
+     */
+    fun runDelayed(
+        runnable: Runnable,
+        retired: Runnable?,
+        delay: Long,
+    ): TaskImplementation<Void>? {
+        val wrapperFunction = Function<TaskImplementation<Void>, Void> { task ->
+            runnable.run()
+            null
+        }
+        return runDelayed(wrapperFunction, retired, delay)
+    }
+
+    /**
+     * Schedules a task to be run after a delay.
+     *
+     * @param function The task to run.
+     * @param delay The delay before the task is run.
+     * @return The task that was scheduled.
+     */
+    fun <T : Any> runDelayed(
+        function: Function<TaskImplementation<T>, T>,
+        delay: Long,
+    ): TaskImplementation<T>? {
+        return runDelayed(function, null, delay)
+    }
 
     /**
      * Schedules a task to be run after a delay.
@@ -65,12 +172,45 @@ interface EntitySchedulerImplementation {
      * @param delay The delay before the task is run.
      * @return The task that was scheduled.
      */
-    fun runDelayed(consumer: Consumer<TaskImplementation>, delay: Long): TaskImplementation? {
+    fun runDelayed(
+        consumer: Consumer<TaskImplementation<Void>>,
+        delay: Long,
+    ): TaskImplementation<Void>? {
         return runDelayed(consumer, null, delay)
     }
 
     /**
-     * Schedules a task to be run after a delay and then repeatedly after a period.
+     * Schedules a task to be run after a delay.
+     *
+     * @param runnable The task to run.
+     * @param delay The delay before the task is run.
+     * @return The task that was scheduled.
+     */
+    fun runDelayed(
+        runnable: Runnable,
+        delay: Long,
+    ): TaskImplementation<Void>? {
+        return runDelayed(runnable, null, delay)
+    }
+
+    /**
+     * Schedules a task to be run after a delay.
+     *
+     * @param function The task to run.
+     * @param retired The task to run if the entity is retired.
+     * @param delay The delay before the task is run.
+     * @param period The period between each run.
+     * @return The task that was scheduled.
+     */
+    fun <T : Any> runAtFixedRate(
+        function: Function<TaskImplementation<T>, T>,
+        retired: Runnable?,
+        delay: Long,
+        period: Long,
+    ): TaskImplementation<T>?
+
+    /**
+     * Schedules a task to be run after a delay.
      *
      * @param consumer The task to run.
      * @param retired The task to run if the entity is retired.
@@ -78,18 +218,87 @@ interface EntitySchedulerImplementation {
      * @param period The period between each run.
      * @return The task that was scheduled.
      */
-    fun runAtFixedRate(consumer: Consumer<TaskImplementation>, retired: Runnable?, delay: Long, period: Long): TaskImplementation?
+    fun runAtFixedRate(
+        consumer: Consumer<TaskImplementation<Void>>,
+        retired: Runnable?,
+        delay: Long,
+        period: Long,
+    ): TaskImplementation<Void>? {
+        val wrapperFunction = Function<TaskImplementation<Void>, Void> { task ->
+            consumer.accept(task)
+            null
+        }
+        return runAtFixedRate(wrapperFunction, retired, delay, period)
+    }
 
     /**
-     * Schedules a task to be run after a delay and then repeatedly after a period.
+     * Schedules a task to be run after a delay.
+     *
+     * @param runnable The task to run.
+     * @param retired The task to run if the entity is retired.
+     * @param delay The delay before the task is run.
+     * @param period The period between each run.
+     * @return The task that was scheduled.
+     */
+    fun runAtFixedRate(
+        runnable: Runnable,
+        retired: Runnable?,
+        delay: Long,
+        period: Long,
+    ): TaskImplementation<Void>? {
+        val wrapperFunction = Function<TaskImplementation<Void>, Void> { task ->
+            runnable.run()
+            null
+        }
+        return runAtFixedRate(wrapperFunction, retired, delay, period)
+    }
+
+    /**
+     * Schedules a task to be run after a delay.
+     *
+     * @param function The task to run.
+     * @param delay The delay before the task is run.
+     * @param period The period between each run.
+     * @return The task that was scheduled.
+     */
+    fun <T : Any> runAtFixedRate(
+        function: Function<TaskImplementation<T>, T>,
+        delay: Long,
+        period: Long,
+    ): TaskImplementation<T>? {
+        return runAtFixedRate(function, null, delay, period)
+    }
+
+    /**
+     * Schedules a task to be run after a delay.
      *
      * @param consumer The task to run.
      * @param delay The delay before the task is run.
      * @param period The period between each run.
      * @return The task that was scheduled.
      */
-    fun runAtFixedRate(consumer: Consumer<TaskImplementation>, delay: Long, period: Long): TaskImplementation? {
+    fun runAtFixedRate(
+        consumer: Consumer<TaskImplementation<Void>>,
+        delay: Long,
+        period: Long,
+    ): TaskImplementation<Void>? {
         return runAtFixedRate(consumer, null, delay, period)
+    }
+
+    /**
+     * Schedules a task to be run after a delay.
+     *
+     * @param runnable The task to run.
+     * @param delay The delay before the task is run.
+     * @param period The period between each run.
+     * @return The task that was scheduled.
+     */
+    fun runAtFixedRate(
+        runnable: Runnable,
+        delay: Long,
+        period: Long,
+    ): TaskImplementation<Void>? {
+        return runAtFixedRate(runnable, null, delay, period)
     }
 }
 

--- a/src/main/kotlin/com/cjcrafter/scheduler/SchedulerImplementation.kt
+++ b/src/main/kotlin/com/cjcrafter/scheduler/SchedulerImplementation.kt
@@ -1,6 +1,7 @@
 package com.cjcrafter.scheduler
 
 import java.util.function.Consumer
+import java.util.function.Function
 
 /**
  * Represents a scheduler that can schedule tasks to be run.
@@ -14,12 +15,52 @@ interface SchedulerImplementation {
     fun execute(run: Runnable)
 
     /**
-     * Schedules a task to be run on the next tick.
+     * Schedules a task to be run after a delay.
+     *
+     * @param function The task to run.
+     * @return The task that was scheduled.
+     */
+    fun <T : Any> run(function: Function<TaskImplementation<T>, T>): TaskImplementation<T>
+
+    /**
+     * Schedules a task to be run after a delay.
      *
      * @param consumer The task to run.
      * @return The task that was scheduled.
      */
-    fun run(consumer: Consumer<TaskImplementation>): TaskImplementation
+    fun run(consumer: Consumer<TaskImplementation<Void>>): TaskImplementation<Void> {
+        val wrapperFunction = Function<TaskImplementation<Void>, Void> { task ->
+            consumer.accept(task)
+            null
+        }
+        return run(wrapperFunction)
+    }
+
+    /**
+     * Schedules a task to be run after a delay.
+     *
+     * @param runnable The task to run.
+     * @return The task that was scheduled.
+     */
+    fun run(runnable: Runnable): TaskImplementation<Void> {
+        val wrapperFunction = Function<TaskImplementation<Void>, Void> { task ->
+            runnable.run()
+            null
+        }
+        return run(wrapperFunction)
+    }
+
+    /**
+     * Schedules a task to be run after a delay.
+     *
+     * @param function The task to run.
+     * @param delay The delay in ticks before the task is run.
+     * @return The task that was scheduled.
+     */
+    fun <T : Any> runDelayed(
+        function: Function<TaskImplementation<T>, T>,
+        delay: Long,
+    ): TaskImplementation<T>
 
     /**
      * Schedules a task to be run after a delay.
@@ -28,15 +69,84 @@ interface SchedulerImplementation {
      * @param delay The delay in ticks before the task is run.
      * @return The task that was scheduled.
      */
-    fun runDelayed(consumer: Consumer<TaskImplementation>, delay: Long): TaskImplementation
+    fun runDelayed(
+        consumer: Consumer<TaskImplementation<Void>>,
+        delay: Long,
+    ): TaskImplementation<Void> {
+        val wrapperFunction = Function<TaskImplementation<Void>, Void> { task ->
+            consumer.accept(task)
+            null
+        }
+        return runDelayed(wrapperFunction, delay)
+
+    }
 
     /**
-     * Schedules a task to be run after a delay and then repeatedly after a period.
+     * Schedules a task to be run after a delay.
      *
-     * @param consumer The task to run.
+     * @param runnable The task to run.
      * @param delay The delay in ticks before the task is run.
-     * @param period The period in ticks between each run.
      * @return The task that was scheduled.
      */
-    fun runAtFixedRate(consumer: Consumer<TaskImplementation>, delay: Long, period: Long): TaskImplementation
+    fun runDelayed(
+        runnable: Runnable,
+        delay: Long,
+    ): TaskImplementation<Void> {
+        val wrapperFunction = Function<TaskImplementation<Void>, Void> { task ->
+            runnable.run()
+            null
+        }
+        return runDelayed(wrapperFunction, delay)
+    }
+
+    /**
+     * Schedules a task to be run after a delay.
+     *
+     * @param function The task to run.
+     * @param delay The delay before the task is run.
+     * @param period The time unit of the delay.
+     */
+    fun <T : Any> runAtFixedRate(
+        function: Function<TaskImplementation<T>, T>,
+        delay: Long,
+        period: Long,
+    ): TaskImplementation<T>
+
+    /**
+     * Schedules a task to be run after a delay.
+     *
+     * @param consumer The task to run.
+     * @param delay The delay before the task is run.
+     * @param period The time unit of the delay.
+     */
+    fun runAtFixedRate(
+        consumer: Consumer<TaskImplementation<Void>>,
+        delay: Long,
+        period: Long,
+    ): TaskImplementation<Void> {
+        val wrapperFunction = Function<TaskImplementation<Void>, Void> { task ->
+            consumer.accept(task)
+            null
+        }
+        return runAtFixedRate(wrapperFunction, delay, period)
+    }
+
+    /**
+     * Schedules a task to be run after a delay.
+     *
+     * @param runnable The task to run.
+     * @param delay The delay before the task is run.
+     * @param period The time unit of the delay.
+     */
+    fun runAtFixedRate(
+        runnable: Runnable,
+        delay: Long,
+        period: Long,
+    ): TaskImplementation<Void> {
+        val wrapperFunction = Function<TaskImplementation<Void>, Void> { task ->
+            runnable.run()
+            null
+        }
+        return runAtFixedRate(wrapperFunction, delay, period)
+    }
 }

--- a/src/main/kotlin/com/cjcrafter/scheduler/TaskImplementation.kt
+++ b/src/main/kotlin/com/cjcrafter/scheduler/TaskImplementation.kt
@@ -35,7 +35,7 @@ interface TaskImplementation<T : Any> {
     /**
      * Returns the callback from this task's execution.
      */
-    fun getCallback(): Optional<T>
+    fun getCallback(): T?
 
     /**
      * Returns a CompletableFuture that will be completed when the task has finished executing. For repeating tasks,

--- a/src/main/kotlin/com/cjcrafter/scheduler/TaskImplementation.kt
+++ b/src/main/kotlin/com/cjcrafter/scheduler/TaskImplementation.kt
@@ -1,6 +1,7 @@
 package com.cjcrafter.scheduler
 
 import org.bukkit.plugin.Plugin
+import org.jetbrains.annotations.ApiStatus
 import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.function.Function
@@ -38,8 +39,11 @@ interface TaskImplementation<T : Any> {
     fun getCallback(): T?
 
     /**
-     * Returns a CompletableFuture that will be completed when the task has finished executing. For repeating tasks,
-     * the future will be completed 1 time for each execution.
+     * Returns a CompletableFuture that will be completed when the task has finished executing.
+     * For repeating tasks, the future will be completed on the first loop execution.
+     *
+     * The future may not be completed if the task is cancelled before it is run, or if an
+     * exception occurs during execution of the task.
      */
     fun asFuture(): CompletableFuture<TaskImplementation<T>>
 }

--- a/src/main/kotlin/com/cjcrafter/scheduler/TaskImplementation.kt
+++ b/src/main/kotlin/com/cjcrafter/scheduler/TaskImplementation.kt
@@ -1,9 +1,11 @@
 package com.cjcrafter.scheduler
 
 import org.bukkit.plugin.Plugin
+import java.util.*
 import java.util.concurrent.CompletableFuture
+import java.util.function.Function
 
-interface TaskImplementation {
+interface TaskImplementation<T : Any> {
 
     /**
      * The plugin that ran this task.
@@ -31,8 +33,13 @@ interface TaskImplementation {
     fun isRepeatingTask(): Boolean
 
     /**
+     * Returns the callback from this task's execution.
+     */
+    fun getCallback(): Optional<T>
+
+    /**
      * Returns a CompletableFuture that will be completed when the task has finished executing. For repeating tasks,
      * the future will be completed 1 time for each execution.
      */
-    fun asFuture(): CompletableFuture<TaskImplementation>
+    fun asFuture(): CompletableFuture<TaskImplementation<T>>
 }


### PR DESCRIPTION
Fix #3 

Adds functional interfaces (`Runnable`, `Consumer<TaskImplementation<Void>>`, `Function<TaskImplementation<T>, T>`)  support to all tasks. This way, java users don't have to type out a bunch of stuff.