### PR TITLE
ReflectionUtil and Paper remapping

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     `java-library`
     `maven-publish`
     signing
+    id("com.gradleup.shadow") version "8.3.2"
     id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,9 @@ dependencies {
     compileOnly("org.spigotmc:spigot-api:1.12.2-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:24.1.0")
 
+    // Remapping classes in paper 1.20.5+
+    implementation("xyz.jpenilla:reflection-remapper:0.1.1")
+
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.2")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,14 +39,10 @@ java {
 }
 
 tasks {
-    jar {
-        enabled = false  // disable default jar task, since we use shadowJar
-    }
-
     shadowJar {
         archiveFileName.set("$githubRepo-$version.jar")
+        archiveClassifier.set("")
 
-        // include spigot and folia subprojects in jar
         dependsOn(":folia:jar", ":spigot:jar")
         from(zipTree(project(":spigot").tasks.jar.get().archiveFile)) {
             exclude("META-INF/**")
@@ -55,7 +51,6 @@ tasks {
             exclude("META-INF/**")
         }
 
-        // relocate essential libs
         relocate("xyz.jpenilla.reflectionremapper", "com.cjcrafter.foliascheduler.reflectionremapper")
         relocate("net.fabricmc.mappingio", "com.cjcrafter.foliascheduler.mappingio")
     }
@@ -72,9 +67,11 @@ tasks {
     }
 
     named<Jar>("sourcesJar") {
+        dependsOn(":folia:jar", ":spigot:jar")
+
         from(sourceSets.main.get().allSource)
-        from(project(":spigot").sourceSets.main.get().allSource)
-        from(project(":folia").sourceSets.main.get().allSource)
+        //from(project(":spigot").sourceSets.main.get().allSource)
+        //from(project(":folia").sourceSets.main.get().allSource)
     }
 
     test {
@@ -106,7 +103,12 @@ signing {
 publishing {
     publications {
         create<MavenPublication>("mavenJava") {
-            from(components["java"])
+            // Use the 'shadow' component for publishing
+            from(components["shadow"])
+
+            // Include sources and javadoc jars
+            artifact(tasks.named<Jar>("sourcesJar").get())
+            artifact(tasks.named<Jar>("javadocJar").get())
 
             pom {
                 name.set(githubRepo)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,13 @@ java {
 
 tasks {
     jar {
-        from(sourceSets.main.get().output)
+        enabled = false  // disable default jar task, since we use shadowJar
+    }
+
+    shadowJar {
+        archiveFileName.set("$githubRepo-$version.jar")
+
+        // include spigot and folia subprojects in jar
         dependsOn(":folia:jar", ":spigot:jar")
         from(zipTree(project(":spigot").tasks.jar.get().archiveFile)) {
             exclude("META-INF/**")
@@ -48,6 +54,10 @@ tasks {
         from(zipTree(project(":folia").tasks.jar.get().archiveFile)) {
             exclude("META-INF/**")
         }
+
+        // relocate essential libs
+        relocate("xyz.jpenilla.reflectionremapper", "com.cjcrafter.foliascheduler.reflectionremapper")
+        relocate("net.fabricmc.mappingio", "com.cjcrafter.foliascheduler.mappingio")
     }
 
     javadoc {

--- a/src/main/java/com/cjcrafter/foliascheduler/util/ConstructorInvoker.java
+++ b/src/main/java/com/cjcrafter/foliascheduler/util/ConstructorInvoker.java
@@ -1,0 +1,72 @@
+package com.cjcrafter.foliascheduler.util;
+
+import org.jetbrains.annotations.NotNull;
+import sun.reflect.CallerSensitive;
+
+import java.lang.reflect.Constructor;
+
+/**
+ * Wraps a {@link Constructor} object from the Java Reflection API and provides
+ * methods to invoke the constructor without having to handle checked exceptions.
+ *
+ * <p>This class delegates methods to the underlying {@code Constructor} object,
+ * but wraps checked exceptions in {@code RuntimeException} to avoid having to
+ * handle them. All {@link ReflectiveOperationException} instances are caught
+ * and rethrown as {@code RuntimeException}. Other runtime exceptions are not
+ * caught and will be thrown as normal.
+ *
+ * @param <T> the type of object that the constructor creates
+ */
+public class ConstructorInvoker<T> {
+
+    private final @NotNull Constructor<T> constructor;
+
+    public ConstructorInvoker(@NotNull Constructor<T> constructor) {
+        this.constructor = constructor;
+    }
+
+    /**
+     * Returns the underlying {@code Constructor} object that this {@code ConstructorInvoker} wraps.
+     *
+     * @return the underlying {@code Constructor} object.
+     */
+    public @NotNull Constructor<T> getConstructor() {
+        return constructor;
+    }
+
+    /**
+     * Uses the constructor represented by this {@code Constructor} object to create and initialize a new instance of the constructor's declaring class, with the specified initialization parameters.
+     * Individual parameters are automatically unwrapped to match primitive formal parameters, and both primitive and reference parameters are subject to method invocation conversions as necessary.
+     *
+     * <p>If the number of formal parameters required by the underlying constructor
+     * is 0, the supplied {@code initargs} array may be of length 0 or null.
+     *
+     * <p>If the constructor's declaring class is an inner class in a
+     * non-static context, the first argument to the constructor needs to be the enclosing instance; see section 15.9.3 of
+     * <cite>The Java&trade; Language Specification</cite>.
+     *
+     * <p>If the required access and argument checks succeed and the
+     * instantiation will proceed, the constructor's declaring class is initialized if it has not already been initialized.
+     *
+     * <p>If the constructor completes normally, returns the newly
+     * created and initialized instance.
+     *
+     * @param initargs array of objects to be passed as arguments to the constructor call; values of primitive types are wrapped in a wrapper object of the appropriate type (e.g. a {@code float} in a
+     * {@link Float Float})
+     * @return a new object created by calling the constructor this object represents
+     * @throws WrappedReflectiveOperationException if this {@code Constructor} object is enforcing Java language access control and the underlying constructor is inaccessible.
+     * @throws IllegalArgumentException if the number of actual and formal parameters differ; if an unwrapping conversion for primitive arguments fails; or if, after possible unwrapping, a parameter value
+     * cannot be converted to the corresponding formal parameter type by a method invocation conversion; if this constructor pertains to an enum type.
+     * @throws WrappedReflectiveOperationException if the class that declares the underlying constructor represents an abstract class.
+     * @throws WrappedReflectiveOperationException if the underlying constructor throws an exception.
+     * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
+     */
+    @CallerSensitive
+    public @NotNull T newInstance(Object... initargs) throws IllegalArgumentException {
+        try {
+            return constructor.newInstance(initargs);
+        } catch (ReflectiveOperationException e) {
+            throw new WrappedReflectiveOperationException(e);
+        }
+    }
+}

--- a/src/main/java/com/cjcrafter/foliascheduler/util/ConstructorInvoker.java
+++ b/src/main/java/com/cjcrafter/foliascheduler/util/ConstructorInvoker.java
@@ -1,7 +1,6 @@
 package com.cjcrafter.foliascheduler.util;
 
 import org.jetbrains.annotations.NotNull;
-import sun.reflect.CallerSensitive;
 
 import java.lang.reflect.Constructor;
 
@@ -61,7 +60,6 @@ public class ConstructorInvoker<T> {
      * @throws WrappedReflectiveOperationException if the underlying constructor throws an exception.
      * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
      */
-    @CallerSensitive
     public @NotNull T newInstance(Object... initargs) throws IllegalArgumentException {
         try {
             return constructor.newInstance(initargs);

--- a/src/main/java/com/cjcrafter/foliascheduler/util/FieldAccessor.java
+++ b/src/main/java/com/cjcrafter/foliascheduler/util/FieldAccessor.java
@@ -1,0 +1,466 @@
+package com.cjcrafter.foliascheduler.util;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import sun.reflect.CallerSensitive;
+
+import java.lang.reflect.Field;
+
+/**
+ * A class that provides access to the {@code Field} class in the Java Reflection API.
+ *
+ * <p>This class provides methods to access the value of a field, set the value of a field without
+ * requiring a try-catch block. Any {@link IllegalAccessException} is caught and rethrown as a
+ * {@link RuntimeException}.
+ */
+public class FieldAccessor {
+
+    private final @NotNull Field field;
+
+    public FieldAccessor(@NotNull Field field) {
+        this.field = field;
+    }
+
+    /**
+     * Returns the {@code Field} object that this {@code FieldAccessor} object represents.
+     *
+     * @return the underlying {@code Field} object
+     */
+    public @NotNull Field getField() {
+        return field;
+    }
+
+    /**
+     * Gets the value of a static or instance {@code boolean} field.
+     *
+     * @param obj the object to extract the {@code boolean} value from
+     * @return the value of the {@code boolean} field
+     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
+     * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if the field value
+     * cannot be converted to the type {@code boolean} by a widening conversion.
+     * @throws NullPointerException if the specified object is null and the field is an instance field.
+     * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
+     * @see Field#get
+     */
+    @CallerSensitive
+    public boolean getBoolean(@Nullable Object obj) throws IllegalArgumentException {
+        try {
+            return field.getBoolean(obj);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Returns the value of the field represented by this {@code Field}, on the specified object. The value is automatically wrapped in an object if it has a primitive type.
+     *
+     * <p>The underlying field's value is obtained as follows:
+     *
+     * <p>If the underlying field is a static field, the {@code obj} argument
+     * is ignored; it may be null.
+     *
+     * <p>Otherwise, the underlying field is an instance field.  If the
+     * specified {@code obj} argument is null, the method throws a {@code NullPointerException}. If the specified object is not an instance of the class or interface declaring the underlying field, the
+     * method throws an {@code IllegalArgumentException}.
+     *
+     * <p>If this {@code Field} object is enforcing Java language access control, and
+     * the underlying field is inaccessible, the method throws an {@code IllegalAccessException}. If the underlying field is static, the class that declared the field is initialized if it has not already
+     * been initialized.
+     *
+     * <p>Otherwise, the value is retrieved from the underlying instance
+     * or static field.  If the field has a primitive type, the value is wrapped in an object before being returned, otherwise it is returned as is.
+     *
+     * <p>If the field is hidden in the type of {@code obj},
+     * the field's value is obtained according to the preceding rules.
+     *
+     * @param obj object from which the represented field's value is to be extracted
+     * @return the value of the represented field in object {@code obj}; primitive values are wrapped in an appropriate object before being returned
+     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
+     * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof).
+     * @throws NullPointerException if the specified object is null and the field is an instance field.
+     * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
+     */
+    @CallerSensitive
+    public @Nullable Object get(@Nullable Object obj) throws IllegalArgumentException {
+        try {
+            return field.get(obj);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Sets the field represented by this {@code Field} object on the specified object argument to the specified new value. The new value is automatically unwrapped if the underlying field has a primitive
+     * type.
+     *
+     * <p>The operation proceeds as follows:
+     *
+     * <p>If the underlying field is static, the {@code obj} argument is
+     * ignored; it may be null.
+     *
+     * <p>Otherwise the underlying field is an instance field.  If the
+     * specified object argument is null, the method throws a {@code NullPointerException}.  If the specified object argument is not an instance of the class or interface declaring the underlying field,
+     * the method throws an {@code IllegalArgumentException}.
+     *
+     * <p>If this {@code Field} object is enforcing Java language access control, and
+     * the underlying field is inaccessible, the method throws an {@code IllegalAccessException}.
+     *
+     * <p>If the underlying field is final, the method throws an
+     * {@code IllegalAccessException} unless {@code setAccessible(true)} has succeeded for this {@code Field} object and the field is non-static. Setting a final field in this way is meaningful only
+     * during deserialization or reconstruction of instances of classes with blank final fields, before they are made available for access by other parts of a program. Use in any other context may have
+     * unpredictable effects, including cases in which other parts of a program continue to use the original value of this field.
+     *
+     * <p>If the underlying field is of a primitive type, an unwrapping
+     * conversion is attempted to convert the new value to a value of a primitive type.  If this attempt fails, the method throws an {@code IllegalArgumentException}.
+     *
+     * <p>If, after possible unwrapping, the new value cannot be
+     * converted to the type of the underlying field by an identity or widening conversion, the method throws an {@code IllegalArgumentException}.
+     *
+     * <p>If the underlying field is static, the class that declared the
+     * field is initialized if it has not already been initialized.
+     *
+     * <p>The field is set to the possibly unwrapped and widened new value.
+     *
+     * <p>If the field is hidden in the type of {@code obj},
+     * the field's value is set according to the preceding rules.
+     *
+     * @param obj the object whose field should be modified
+     * @param value the new value for the field of {@code obj} being modified
+     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
+     * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if an unwrapping
+     * conversion fails.
+     * @throws NullPointerException if the specified object is null and the field is an instance field.
+     * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
+     */
+    @CallerSensitive
+    public void set(@Nullable Object obj, @Nullable Object value) throws IllegalArgumentException {
+        try {
+            field.set(obj, value);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Sets the value of a field as a {@code float} on the specified object. This method is equivalent to {@code set(obj, fObj)}, where {@code fObj} is a {@code Float} object and
+     * {@code fObj.floatValue() == f}.
+     *
+     * @param obj the object whose field should be modified
+     * @param f the new value for the field of {@code obj} being modified
+     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
+     * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if an unwrapping
+     * conversion fails.
+     * @throws NullPointerException if the specified object is null and the field is an instance field.
+     * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
+     * @see Field#set
+     */
+    @CallerSensitive
+    public void setFloat(@Nullable Object obj, float f) throws IllegalArgumentException {
+        try {
+            field.setFloat(obj, f);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Gets the value of a static or instance {@code byte} field.
+     *
+     * @param obj the object to extract the {@code byte} value from
+     * @return the value of the {@code byte} field
+     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
+     * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if the field value
+     * cannot be converted to the type {@code byte} by a widening conversion.
+     * @throws NullPointerException if the specified object is null and the field is an instance field.
+     * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
+     * @see Field#get
+     */
+    @CallerSensitive
+    public byte getByte(@Nullable Object obj) throws IllegalArgumentException {
+        try {
+            return field.getByte(obj);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Sets the value of a field as a {@code boolean} on the specified object. This method is equivalent to {@code set(obj, zObj)}, where {@code zObj} is a {@code Boolean} object and
+     * {@code zObj.booleanValue() == z}.
+     *
+     * @param obj the object whose field should be modified
+     * @param z the new value for the field of {@code obj} being modified
+     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
+     * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if an unwrapping
+     * conversion fails.
+     * @throws NullPointerException if the specified object is null and the field is an instance field.
+     * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
+     * @see Field#set
+     */
+    @CallerSensitive
+    public void setBoolean(@Nullable Object obj, boolean z) throws IllegalArgumentException {
+        try {
+            field.setBoolean(obj, z);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Gets the value of a static or instance field of type {@code char} or of another primitive type convertible to type {@code char} via a widening conversion.
+     *
+     * @param obj the object to extract the {@code char} value from
+     * @return the value of the field converted to type {@code char}
+     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
+     * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if the field value
+     * cannot be converted to the type {@code char} by a widening conversion.
+     * @throws NullPointerException if the specified object is null and the field is an instance field.
+     * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
+     * @see Field#get
+     */
+    @CallerSensitive
+    public char getChar(@Nullable Object obj) throws IllegalArgumentException {
+        try {
+            return field.getChar(obj);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Sets the value of a field as a {@code double} on the specified object. This method is equivalent to {@code set(obj, dObj)}, where {@code dObj} is a {@code Double} object and
+     * {@code dObj.doubleValue() == d}.
+     *
+     * @param obj the object whose field should be modified
+     * @param d the new value for the field of {@code obj} being modified
+     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
+     * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if an unwrapping
+     * conversion fails.
+     * @throws NullPointerException if the specified object is null and the field is an instance field.
+     * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
+     * @see Field#set
+     */
+    @CallerSensitive
+    public void setDouble(@Nullable Object obj, double d) throws IllegalArgumentException {
+        try {
+            field.setDouble(obj, d);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Sets the value of a field as a {@code byte} on the specified object. This method is equivalent to {@code set(obj, bObj)}, where {@code bObj} is a {@code Byte} object and
+     * {@code bObj.byteValue() == b}.
+     *
+     * @param obj the object whose field should be modified
+     * @param b the new value for the field of {@code obj} being modified
+     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
+     * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if an unwrapping
+     * conversion fails.
+     * @throws NullPointerException if the specified object is null and the field is an instance field.
+     * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
+     * @see Field#set
+     */
+    @CallerSensitive
+    public void setByte(@Nullable Object obj, byte b) throws IllegalArgumentException {
+        try {
+            field.setByte(obj, b);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Gets the value of a static or instance field of type {@code short} or of another primitive type convertible to type {@code short} via a widening conversion.
+     *
+     * @param obj the object to extract the {@code short} value from
+     * @return the value of the field converted to type {@code short}
+     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
+     * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if the field value
+     * cannot be converted to the type {@code short} by a widening conversion.
+     * @throws NullPointerException if the specified object is null and the field is an instance field.
+     * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
+     * @see Field#get
+     */
+    @CallerSensitive
+    public short getShort(@Nullable Object obj) throws IllegalArgumentException {
+        try {
+            return field.getShort(obj);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Sets the value of a field as a {@code char} on the specified object. This method is equivalent to {@code set(obj, cObj)}, where {@code cObj} is a {@code Character} object and
+     * {@code cObj.charValue() == c}.
+     *
+     * @param obj the object whose field should be modified
+     * @param c the new value for the field of {@code obj} being modified
+     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
+     * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if an unwrapping
+     * conversion fails.
+     * @throws NullPointerException if the specified object is null and the field is an instance field.
+     * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
+     * @see Field#set
+     */
+    @CallerSensitive
+    public void setChar(@Nullable Object obj, char c) throws IllegalArgumentException {
+        try {
+            field.setChar(obj, c);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Gets the value of a static or instance field of type {@code int} or of another primitive type convertible to type {@code int} via a widening conversion.
+     *
+     * @param obj the object to extract the {@code int} value from
+     * @return the value of the field converted to type {@code int}
+     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
+     * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if the field value
+     * cannot be converted to the type {@code int} by a widening conversion.
+     * @throws NullPointerException if the specified object is null and the field is an instance field.
+     * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
+     * @see Field#get
+     */
+    @CallerSensitive
+    public int getInt(@Nullable Object obj) throws IllegalArgumentException {
+        try {
+            return field.getInt(obj);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Gets the value of a static or instance field of type {@code long} or of another primitive type convertible to type {@code long} via a widening conversion.
+     *
+     * @param obj the object to extract the {@code long} value from
+     * @return the value of the field converted to type {@code long}
+     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
+     * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if the field value
+     * cannot be converted to the type {@code long} by a widening conversion.
+     * @throws NullPointerException if the specified object is null and the field is an instance field.
+     * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
+     * @see Field#get
+     */
+    @CallerSensitive
+    public long getLong(@Nullable Object obj) throws IllegalArgumentException {
+        try {
+            return field.getLong(obj);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Sets the value of a field as a {@code short} on the specified object. This method is equivalent to {@code set(obj, sObj)}, where {@code sObj} is a {@code Short} object and
+     * {@code sObj.shortValue() == s}.
+     *
+     * @param obj the object whose field should be modified
+     * @param s the new value for the field of {@code obj} being modified
+     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
+     * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if an unwrapping
+     * conversion fails.
+     * @throws NullPointerException if the specified object is null and the field is an instance field.
+     * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
+     * @see Field#set
+     */
+    @CallerSensitive
+    public void setShort(@Nullable Object obj, short s) throws IllegalArgumentException {
+        try {
+            field.setShort(obj, s);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Sets the value of a field as an {@code int} on the specified object. This method is equivalent to {@code set(obj, iObj)}, where {@code iObj} is a {@code Integer} object and
+     * {@code iObj.intValue() == i}.
+     *
+     * @param obj the object whose field should be modified
+     * @param i the new value for the field of {@code obj} being modified
+     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
+     * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if an unwrapping
+     * conversion fails.
+     * @throws NullPointerException if the specified object is null and the field is an instance field.
+     * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
+     * @see Field#set
+     */
+    @CallerSensitive
+    public void setInt(@Nullable Object obj, int i) throws IllegalArgumentException {
+        try {
+            field.setInt(obj, i);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Gets the value of a static or instance field of type {@code float} or of another primitive type convertible to type {@code float} via a widening conversion.
+     *
+     * @param obj the object to extract the {@code float} value from
+     * @return the value of the field converted to type {@code float}
+     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
+     * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if the field value
+     * cannot be converted to the type {@code float} by a widening conversion.
+     * @throws NullPointerException if the specified object is null and the field is an instance field.
+     * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
+     * @see Field#get
+     */
+    @CallerSensitive
+    public float getFloat(@Nullable Object obj) throws IllegalArgumentException {
+        try {
+            return field.getFloat(obj);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Gets the value of a static or instance field of type {@code double} or of another primitive type convertible to type {@code double} via a widening conversion.
+     *
+     * @param obj the object to extract the {@code double} value from
+     * @return the value of the field converted to type {@code double}
+     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
+     * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if the field value
+     * cannot be converted to the type {@code double} by a widening conversion.
+     * @throws NullPointerException if the specified object is null and the field is an instance field.
+     * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
+     * @see Field#get
+     */
+    @CallerSensitive
+    public double getDouble(@Nullable Object obj) throws IllegalArgumentException {
+        try {
+            return field.getDouble(obj);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Sets the value of a field as a {@code long} on the specified object. This method is equivalent to {@code set(obj, lObj)}, where {@code lObj} is a {@code Long} object and
+     * {@code lObj.longValue() == l}.
+     *
+     * @param obj the object whose field should be modified
+     * @param l the new value for the field of {@code obj} being modified
+     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
+     * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if an unwrapping
+     * conversion fails.
+     * @throws NullPointerException if the specified object is null and the field is an instance field.
+     * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
+     * @see Field#set
+     */
+    @CallerSensitive
+    public void setLong(@Nullable Object obj, long l) throws IllegalArgumentException {
+        try {
+            field.setLong(obj, l);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/cjcrafter/foliascheduler/util/FieldAccessor.java
+++ b/src/main/java/com/cjcrafter/foliascheduler/util/FieldAccessor.java
@@ -11,7 +11,7 @@ import java.lang.reflect.Field;
  *
  * <p>This class provides methods to access the value of a field, set the value of a field without
  * requiring a try-catch block. Any {@link IllegalAccessException} is caught and rethrown as a
- * {@link RuntimeException}.
+ * {@link WrappedReflectiveOperationException}.
  */
 public class FieldAccessor {
 
@@ -35,7 +35,7 @@ public class FieldAccessor {
      *
      * @param obj the object to extract the {@code boolean} value from
      * @return the value of the {@code boolean} field
-     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
+     * @throws WrappedReflectiveOperationException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
      * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if the field value
      * cannot be converted to the type {@code boolean} by a widening conversion.
      * @throws NullPointerException if the specified object is null and the field is an instance field.
@@ -47,7 +47,7 @@ public class FieldAccessor {
         try {
             return field.getBoolean(obj);
         } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+            throw new WrappedReflectiveOperationException(e);
         }
     }
 
@@ -75,7 +75,7 @@ public class FieldAccessor {
      *
      * @param obj object from which the represented field's value is to be extracted
      * @return the value of the represented field in object {@code obj}; primitive values are wrapped in an appropriate object before being returned
-     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
+     * @throws WrappedReflectiveOperationException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
      * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof).
      * @throws NullPointerException if the specified object is null and the field is an instance field.
      * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
@@ -85,7 +85,7 @@ public class FieldAccessor {
         try {
             return field.get(obj);
         } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+            throw new WrappedReflectiveOperationException(e);
         }
     }
 
@@ -126,7 +126,7 @@ public class FieldAccessor {
      *
      * @param obj the object whose field should be modified
      * @param value the new value for the field of {@code obj} being modified
-     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
+     * @throws WrappedReflectiveOperationException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
      * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if an unwrapping
      * conversion fails.
      * @throws NullPointerException if the specified object is null and the field is an instance field.
@@ -137,7 +137,7 @@ public class FieldAccessor {
         try {
             field.set(obj, value);
         } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+            throw new WrappedReflectiveOperationException(e);
         }
     }
 
@@ -147,7 +147,7 @@ public class FieldAccessor {
      *
      * @param obj the object whose field should be modified
      * @param f the new value for the field of {@code obj} being modified
-     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
+     * @throws WrappedReflectiveOperationException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
      * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if an unwrapping
      * conversion fails.
      * @throws NullPointerException if the specified object is null and the field is an instance field.
@@ -159,7 +159,7 @@ public class FieldAccessor {
         try {
             field.setFloat(obj, f);
         } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+            throw new WrappedReflectiveOperationException(e);
         }
     }
 
@@ -168,7 +168,7 @@ public class FieldAccessor {
      *
      * @param obj the object to extract the {@code byte} value from
      * @return the value of the {@code byte} field
-     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
+     * @throws WrappedReflectiveOperationException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
      * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if the field value
      * cannot be converted to the type {@code byte} by a widening conversion.
      * @throws NullPointerException if the specified object is null and the field is an instance field.
@@ -180,7 +180,7 @@ public class FieldAccessor {
         try {
             return field.getByte(obj);
         } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+            throw new WrappedReflectiveOperationException(e);
         }
     }
 
@@ -190,7 +190,7 @@ public class FieldAccessor {
      *
      * @param obj the object whose field should be modified
      * @param z the new value for the field of {@code obj} being modified
-     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
+     * @throws WrappedReflectiveOperationException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
      * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if an unwrapping
      * conversion fails.
      * @throws NullPointerException if the specified object is null and the field is an instance field.
@@ -202,7 +202,7 @@ public class FieldAccessor {
         try {
             field.setBoolean(obj, z);
         } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+            throw new WrappedReflectiveOperationException(e);
         }
     }
 
@@ -211,7 +211,7 @@ public class FieldAccessor {
      *
      * @param obj the object to extract the {@code char} value from
      * @return the value of the field converted to type {@code char}
-     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
+     * @throws WrappedReflectiveOperationException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
      * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if the field value
      * cannot be converted to the type {@code char} by a widening conversion.
      * @throws NullPointerException if the specified object is null and the field is an instance field.
@@ -223,7 +223,7 @@ public class FieldAccessor {
         try {
             return field.getChar(obj);
         } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+            throw new WrappedReflectiveOperationException(e);
         }
     }
 
@@ -233,7 +233,7 @@ public class FieldAccessor {
      *
      * @param obj the object whose field should be modified
      * @param d the new value for the field of {@code obj} being modified
-     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
+     * @throws WrappedReflectiveOperationException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
      * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if an unwrapping
      * conversion fails.
      * @throws NullPointerException if the specified object is null and the field is an instance field.
@@ -245,7 +245,7 @@ public class FieldAccessor {
         try {
             field.setDouble(obj, d);
         } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+            throw new WrappedReflectiveOperationException(e);
         }
     }
 
@@ -255,7 +255,7 @@ public class FieldAccessor {
      *
      * @param obj the object whose field should be modified
      * @param b the new value for the field of {@code obj} being modified
-     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
+     * @throws WrappedReflectiveOperationException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
      * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if an unwrapping
      * conversion fails.
      * @throws NullPointerException if the specified object is null and the field is an instance field.
@@ -267,7 +267,7 @@ public class FieldAccessor {
         try {
             field.setByte(obj, b);
         } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+            throw new WrappedReflectiveOperationException(e);
         }
     }
 
@@ -276,7 +276,7 @@ public class FieldAccessor {
      *
      * @param obj the object to extract the {@code short} value from
      * @return the value of the field converted to type {@code short}
-     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
+     * @throws WrappedReflectiveOperationException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
      * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if the field value
      * cannot be converted to the type {@code short} by a widening conversion.
      * @throws NullPointerException if the specified object is null and the field is an instance field.
@@ -288,7 +288,7 @@ public class FieldAccessor {
         try {
             return field.getShort(obj);
         } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+            throw new WrappedReflectiveOperationException(e);
         }
     }
 
@@ -298,7 +298,7 @@ public class FieldAccessor {
      *
      * @param obj the object whose field should be modified
      * @param c the new value for the field of {@code obj} being modified
-     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
+     * @throws WrappedReflectiveOperationException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
      * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if an unwrapping
      * conversion fails.
      * @throws NullPointerException if the specified object is null and the field is an instance field.
@@ -310,7 +310,7 @@ public class FieldAccessor {
         try {
             field.setChar(obj, c);
         } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+            throw new WrappedReflectiveOperationException(e);
         }
     }
 
@@ -319,7 +319,7 @@ public class FieldAccessor {
      *
      * @param obj the object to extract the {@code int} value from
      * @return the value of the field converted to type {@code int}
-     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
+     * @throws WrappedReflectiveOperationException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
      * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if the field value
      * cannot be converted to the type {@code int} by a widening conversion.
      * @throws NullPointerException if the specified object is null and the field is an instance field.
@@ -331,7 +331,7 @@ public class FieldAccessor {
         try {
             return field.getInt(obj);
         } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+            throw new WrappedReflectiveOperationException(e);
         }
     }
 
@@ -340,7 +340,7 @@ public class FieldAccessor {
      *
      * @param obj the object to extract the {@code long} value from
      * @return the value of the field converted to type {@code long}
-     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
+     * @throws WrappedReflectiveOperationException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
      * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if the field value
      * cannot be converted to the type {@code long} by a widening conversion.
      * @throws NullPointerException if the specified object is null and the field is an instance field.
@@ -352,7 +352,7 @@ public class FieldAccessor {
         try {
             return field.getLong(obj);
         } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+            throw new WrappedReflectiveOperationException(e);
         }
     }
 
@@ -362,7 +362,7 @@ public class FieldAccessor {
      *
      * @param obj the object whose field should be modified
      * @param s the new value for the field of {@code obj} being modified
-     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
+     * @throws WrappedReflectiveOperationException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
      * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if an unwrapping
      * conversion fails.
      * @throws NullPointerException if the specified object is null and the field is an instance field.
@@ -374,7 +374,7 @@ public class FieldAccessor {
         try {
             field.setShort(obj, s);
         } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+            throw new WrappedReflectiveOperationException(e);
         }
     }
 
@@ -384,7 +384,7 @@ public class FieldAccessor {
      *
      * @param obj the object whose field should be modified
      * @param i the new value for the field of {@code obj} being modified
-     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
+     * @throws WrappedReflectiveOperationException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
      * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if an unwrapping
      * conversion fails.
      * @throws NullPointerException if the specified object is null and the field is an instance field.
@@ -396,7 +396,7 @@ public class FieldAccessor {
         try {
             field.setInt(obj, i);
         } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+            throw new WrappedReflectiveOperationException(e);
         }
     }
 
@@ -405,7 +405,7 @@ public class FieldAccessor {
      *
      * @param obj the object to extract the {@code float} value from
      * @return the value of the field converted to type {@code float}
-     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
+     * @throws WrappedReflectiveOperationException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
      * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if the field value
      * cannot be converted to the type {@code float} by a widening conversion.
      * @throws NullPointerException if the specified object is null and the field is an instance field.
@@ -417,7 +417,7 @@ public class FieldAccessor {
         try {
             return field.getFloat(obj);
         } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+            throw new WrappedReflectiveOperationException(e);
         }
     }
 
@@ -426,7 +426,7 @@ public class FieldAccessor {
      *
      * @param obj the object to extract the {@code double} value from
      * @return the value of the field converted to type {@code double}
-     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
+     * @throws WrappedReflectiveOperationException if this {@code Field} object is enforcing Java language access control and the underlying field is inaccessible.
      * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if the field value
      * cannot be converted to the type {@code double} by a widening conversion.
      * @throws NullPointerException if the specified object is null and the field is an instance field.
@@ -438,7 +438,7 @@ public class FieldAccessor {
         try {
             return field.getDouble(obj);
         } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+            throw new WrappedReflectiveOperationException(e);
         }
     }
 
@@ -448,7 +448,7 @@ public class FieldAccessor {
      *
      * @param obj the object whose field should be modified
      * @param l the new value for the field of {@code obj} being modified
-     * @throws RuntimeException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
+     * @throws WrappedReflectiveOperationException if this {@code Field} object is enforcing Java language access control and the underlying field is either inaccessible or final.
      * @throws IllegalArgumentException if the specified object is not an instance of the class or interface declaring the underlying field (or a subclass or implementor thereof), or if an unwrapping
      * conversion fails.
      * @throws NullPointerException if the specified object is null and the field is an instance field.
@@ -460,7 +460,7 @@ public class FieldAccessor {
         try {
             field.setLong(obj, l);
         } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+            throw new WrappedReflectiveOperationException(e);
         }
     }
 }

--- a/src/main/java/com/cjcrafter/foliascheduler/util/FieldAccessor.java
+++ b/src/main/java/com/cjcrafter/foliascheduler/util/FieldAccessor.java
@@ -2,7 +2,6 @@ package com.cjcrafter.foliascheduler.util;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import sun.reflect.CallerSensitive;
 
 import java.lang.reflect.Field;
 
@@ -42,7 +41,6 @@ public class FieldAccessor {
      * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
      * @see Field#get
      */
-    @CallerSensitive
     public boolean getBoolean(@Nullable Object obj) throws IllegalArgumentException {
         try {
             return field.getBoolean(obj);
@@ -80,7 +78,6 @@ public class FieldAccessor {
      * @throws NullPointerException if the specified object is null and the field is an instance field.
      * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
      */
-    @CallerSensitive
     public @Nullable Object get(@Nullable Object obj) throws IllegalArgumentException {
         try {
             return field.get(obj);
@@ -132,7 +129,6 @@ public class FieldAccessor {
      * @throws NullPointerException if the specified object is null and the field is an instance field.
      * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
      */
-    @CallerSensitive
     public void set(@Nullable Object obj, @Nullable Object value) throws IllegalArgumentException {
         try {
             field.set(obj, value);
@@ -154,7 +150,6 @@ public class FieldAccessor {
      * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
      * @see Field#set
      */
-    @CallerSensitive
     public void setFloat(@Nullable Object obj, float f) throws IllegalArgumentException {
         try {
             field.setFloat(obj, f);
@@ -175,7 +170,6 @@ public class FieldAccessor {
      * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
      * @see Field#get
      */
-    @CallerSensitive
     public byte getByte(@Nullable Object obj) throws IllegalArgumentException {
         try {
             return field.getByte(obj);
@@ -197,7 +191,6 @@ public class FieldAccessor {
      * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
      * @see Field#set
      */
-    @CallerSensitive
     public void setBoolean(@Nullable Object obj, boolean z) throws IllegalArgumentException {
         try {
             field.setBoolean(obj, z);
@@ -218,7 +211,6 @@ public class FieldAccessor {
      * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
      * @see Field#get
      */
-    @CallerSensitive
     public char getChar(@Nullable Object obj) throws IllegalArgumentException {
         try {
             return field.getChar(obj);
@@ -240,7 +232,6 @@ public class FieldAccessor {
      * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
      * @see Field#set
      */
-    @CallerSensitive
     public void setDouble(@Nullable Object obj, double d) throws IllegalArgumentException {
         try {
             field.setDouble(obj, d);
@@ -262,7 +253,6 @@ public class FieldAccessor {
      * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
      * @see Field#set
      */
-    @CallerSensitive
     public void setByte(@Nullable Object obj, byte b) throws IllegalArgumentException {
         try {
             field.setByte(obj, b);
@@ -283,7 +273,6 @@ public class FieldAccessor {
      * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
      * @see Field#get
      */
-    @CallerSensitive
     public short getShort(@Nullable Object obj) throws IllegalArgumentException {
         try {
             return field.getShort(obj);
@@ -305,7 +294,6 @@ public class FieldAccessor {
      * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
      * @see Field#set
      */
-    @CallerSensitive
     public void setChar(@Nullable Object obj, char c) throws IllegalArgumentException {
         try {
             field.setChar(obj, c);
@@ -326,7 +314,6 @@ public class FieldAccessor {
      * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
      * @see Field#get
      */
-    @CallerSensitive
     public int getInt(@Nullable Object obj) throws IllegalArgumentException {
         try {
             return field.getInt(obj);
@@ -347,7 +334,6 @@ public class FieldAccessor {
      * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
      * @see Field#get
      */
-    @CallerSensitive
     public long getLong(@Nullable Object obj) throws IllegalArgumentException {
         try {
             return field.getLong(obj);
@@ -369,7 +355,6 @@ public class FieldAccessor {
      * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
      * @see Field#set
      */
-    @CallerSensitive
     public void setShort(@Nullable Object obj, short s) throws IllegalArgumentException {
         try {
             field.setShort(obj, s);
@@ -391,7 +376,6 @@ public class FieldAccessor {
      * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
      * @see Field#set
      */
-    @CallerSensitive
     public void setInt(@Nullable Object obj, int i) throws IllegalArgumentException {
         try {
             field.setInt(obj, i);
@@ -412,7 +396,6 @@ public class FieldAccessor {
      * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
      * @see Field#get
      */
-    @CallerSensitive
     public float getFloat(@Nullable Object obj) throws IllegalArgumentException {
         try {
             return field.getFloat(obj);
@@ -433,7 +416,6 @@ public class FieldAccessor {
      * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
      * @see Field#get
      */
-    @CallerSensitive
     public double getDouble(@Nullable Object obj) throws IllegalArgumentException {
         try {
             return field.getDouble(obj);
@@ -455,7 +437,6 @@ public class FieldAccessor {
      * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
      * @see Field#set
      */
-    @CallerSensitive
     public void setLong(@Nullable Object obj, long l) throws IllegalArgumentException {
         try {
             field.setLong(obj, l);

--- a/src/main/java/com/cjcrafter/foliascheduler/util/MethodInvoker.java
+++ b/src/main/java/com/cjcrafter/foliascheduler/util/MethodInvoker.java
@@ -2,7 +2,6 @@ package com.cjcrafter.foliascheduler.util;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import sun.reflect.CallerSensitive;
 
 import java.lang.reflect.Method;
 
@@ -65,7 +64,6 @@ public class MethodInvoker {
      * @throws NullPointerException if the specified object is null and the method is an instance method.
      * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
      */
-    @CallerSensitive
     public @Nullable Object invoke(@Nullable Object obj, Object... args) throws IllegalArgumentException {
         try {
             return method.invoke(obj, args);

--- a/src/main/java/com/cjcrafter/foliascheduler/util/MethodInvoker.java
+++ b/src/main/java/com/cjcrafter/foliascheduler/util/MethodInvoker.java
@@ -57,11 +57,11 @@ public class MethodInvoker {
      * @param obj the object the underlying method is invoked from
      * @param args the arguments used for the method call
      * @return the result of dispatching the method represented by this object on {@code obj} with parameters {@code args}
-     * @throws RuntimeException if this {@code Method} object is enforcing Java language access control and the underlying method is inaccessible.
+     * @throws WrappedReflectiveOperationException if this {@code Method} object is enforcing Java language access control and the underlying method is inaccessible.
      * @throws IllegalArgumentException if the method is an instance method and the specified object argument is not an instance of the class or interface declaring the underlying method (or of a subclass
      * or implementor thereof); if the number of actual and formal parameters differ; if an unwrapping conversion for primitive arguments fails; or if, after possible unwrapping, a parameter value cannot
      * be converted to the corresponding formal parameter type by a method invocation conversion.
-     * @throws RuntimeException if the underlying method throws an exception.
+     * @throws WrappedReflectiveOperationException if the underlying method throws an exception.
      * @throws NullPointerException if the specified object is null and the method is an instance method.
      * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
      */
@@ -70,7 +70,7 @@ public class MethodInvoker {
         try {
             return method.invoke(obj, args);
         } catch (ReflectiveOperationException e) {
-            throw new RuntimeException(e);
+            throw new WrappedReflectiveOperationException(e);
         }
     }
 }

--- a/src/main/java/com/cjcrafter/foliascheduler/util/MethodInvoker.java
+++ b/src/main/java/com/cjcrafter/foliascheduler/util/MethodInvoker.java
@@ -1,0 +1,76 @@
+package com.cjcrafter.foliascheduler.util;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import sun.reflect.CallerSensitive;
+
+import java.lang.reflect.Method;
+
+/**
+ * Wraps a {@link Method} object from the Java Reflection API and provides
+ * methods to invoke the method without having to handle checked exceptions.
+ *
+ * <p>This class delegates methods to the underlying {@code Method} object,
+ * but wraps checked exceptions in {@code RuntimeException} to avoid having to
+ * handle them. All {@link ReflectiveOperationException} instances are caught
+ * and rethrown as {@code RuntimeException}. Other runtime exceptions are not
+ * caught and will be thrown as normal.
+ */
+public class MethodInvoker {
+
+    private final @NotNull Method method;
+
+    public MethodInvoker(@NotNull Method method) {
+        this.method = method;
+    }
+
+    /**
+     * Returns the underlying {@code Method} object that this {@code MethodInvoker} wraps.
+     *
+     * @return the underlying {@code Method} object
+     */
+    public @NotNull Method getMethod() {
+        return method;
+    }
+
+    /**
+     * Invokes the underlying method represented by this {@code Method} object, on the specified object with the specified parameters. Individual parameters are automatically unwrapped to match primitive
+     * formal parameters, and both primitive and reference parameters are subject to method invocation conversions as necessary.
+     *
+     * <p>If the underlying method is static, then the specified {@code obj}
+     * argument is ignored. It may be null.
+     *
+     * <p>If the number of formal parameters required by the underlying method is
+     * 0, the supplied {@code args} array may be of length 0 or null.
+     *
+     * <p>If the underlying method is an instance method, it is invoked
+     * using dynamic method lookup as documented in The Java Language Specification, Second Edition, section 15.12.4.4; in particular, overriding based on the runtime type of the target object will
+     * occur.
+     *
+     * <p>If the underlying method is static, the class that declared
+     * the method is initialized if it has not already been initialized.
+     *
+     * <p>If the method completes normally, the value it returns is
+     * returned to the caller of invoke; if the value has a primitive type, it is first appropriately wrapped in an object. However, if the value has the type of an array of a primitive type, the elements
+     * of the array are <i>not</i> wrapped in objects; in other words, an array of primitive type is returned.  If the underlying method return type is void, the invocation returns null.
+     *
+     * @param obj the object the underlying method is invoked from
+     * @param args the arguments used for the method call
+     * @return the result of dispatching the method represented by this object on {@code obj} with parameters {@code args}
+     * @throws RuntimeException if this {@code Method} object is enforcing Java language access control and the underlying method is inaccessible.
+     * @throws IllegalArgumentException if the method is an instance method and the specified object argument is not an instance of the class or interface declaring the underlying method (or of a subclass
+     * or implementor thereof); if the number of actual and formal parameters differ; if an unwrapping conversion for primitive arguments fails; or if, after possible unwrapping, a parameter value cannot
+     * be converted to the corresponding formal parameter type by a method invocation conversion.
+     * @throws RuntimeException if the underlying method throws an exception.
+     * @throws NullPointerException if the specified object is null and the method is an instance method.
+     * @throws ExceptionInInitializerError if the initialization provoked by this method fails.
+     */
+    @CallerSensitive
+    public @Nullable Object invoke(@Nullable Object obj, Object... args) throws IllegalArgumentException {
+        try {
+            return method.invoke(obj, args);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/cjcrafter/foliascheduler/util/ReflectionUtil.java
+++ b/src/main/java/com/cjcrafter/foliascheduler/util/ReflectionUtil.java
@@ -109,8 +109,8 @@ public final class ReflectionUtil {
     }
 
     /**
-     * Returns the org.bukkit.craftbukkit {@link Class} object with the specified relative path.
-     * This method calls {@link #getClass(String)}.
+     * Returns the {@link Class} object from the org.bukkit.craftbukkit package with the specified
+     * relative path. This method calls {@link #getClass(String)}.
      *
      * <p>For example, to get the class <code>org.bukkit.craftbukkit.v1_17_R1.entity.CraftPlayer</code>,
      * you would call <code>getCraftBukkitClass("entity.CraftPlayer")</code>.

--- a/src/main/java/com/cjcrafter/foliascheduler/util/ReflectionUtil.java
+++ b/src/main/java/com/cjcrafter/foliascheduler/util/ReflectionUtil.java
@@ -69,7 +69,7 @@ public final class ReflectionUtil {
      */
     public static <T> @NotNull Class<T> getClass(@NotNull String className) {
         // In Paper 1.20.5+, Paper remaps the server to Mojang mappings
-        if (MinecraftVersions.TRAILS_AND_TAILS.get(5).isAtLeast() && ServerVersions.isPaper()) {
+        if (ServerVersions.isPaper() && MinecraftVersions.TRAILS_AND_TAILS.get(5).isAtLeast()) {
             ReflectionRemapper remapper = ReflectionRemapper.forReobfMappingsInPaperJar();
             className = remapper.remapClassOrArrayName(className);
         }
@@ -133,7 +133,7 @@ public final class ReflectionUtil {
     public static @NotNull FieldAccessor getField(@NotNull Class<?> clazz, @NotNull String fieldName) {
         try {
             // In Paper 1.20.5+, Paper remaps the server to Mojang mappings
-            if (MinecraftVersions.TRAILS_AND_TAILS.get(5).isAtLeast() && ServerVersions.isPaper()) {
+            if (ServerVersions.isPaper() && MinecraftVersions.TRAILS_AND_TAILS.get(5).isAtLeast()) {
                 ReflectionRemapper remapper = ReflectionRemapper.forReobfMappingsInPaperJar();
                 fieldName = remapper.remapFieldName(clazz, fieldName);
             }
@@ -214,7 +214,7 @@ public final class ReflectionUtil {
     public static @NotNull MethodInvoker getMethod(@NotNull Class<?> clazz, @NotNull String methodName, Class<?>... parameterTypes) {
         try {
             // In Paper 1.20.5+, Paper remaps the server to Mojang mappings
-            if (MinecraftVersions.TRAILS_AND_TAILS.get(5).isAtLeast() && ServerVersions.isPaper()) {
+            if (ServerVersions.isPaper() && MinecraftVersions.TRAILS_AND_TAILS.get(5).isAtLeast()) {
                 ReflectionRemapper remapper = ReflectionRemapper.forReobfMappingsInPaperJar();
                 methodName = remapper.remapMethodName(clazz, methodName);
             }

--- a/src/main/java/com/cjcrafter/foliascheduler/util/ReflectionUtil.java
+++ b/src/main/java/com/cjcrafter/foliascheduler/util/ReflectionUtil.java
@@ -1,0 +1,303 @@
+package com.cjcrafter.foliascheduler.util;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import xyz.jpenilla.reflectionremapper.ReflectionRemapper;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.function.Predicate;
+
+/**
+ * A utility class that wraps the Java Reflection API and provides methods to
+ * access classes and constructors without having to handle checked exceptions.
+ *
+ * <p>This class delegates methods to the underlying Java Reflection API,
+ * but wraps checked exceptions in {@link WrappedReflectiveOperationException}.
+ * You can get the original exception by calling {@link WrappedReflectiveOperationException#getCause()}.
+ *
+ * <p>This class handles the remapping of class names, field names, and method names
+ * when running on Paper 1.20.5+. Because of the remapping, these methods will be
+ * even slower than the normal Java Reflection API. This means that you should be
+ * saving the results of these methods, typically in a <code>static final</code>
+ * field, to avoid the performance penalty of reflection.
+ */
+public final class ReflectionUtil {
+
+    // These predicates can be used in #getField and #getMethod to filter fields more precisely
+    public static final @NotNull Predicate<Member> IS_STATIC = (member) -> Modifier.isStatic(member.getModifiers());
+    public static final @NotNull Predicate<Member> IS_NON_STATIC = IS_STATIC.negate();
+    public static final @NotNull Predicate<Member> IS_FINAL = (member) -> Modifier.isFinal(member.getModifiers());
+    public static final @NotNull Predicate<Member> IS_NON_FINAL = IS_FINAL.negate();
+
+    private ReflectionUtil() {
+        throw new UnsupportedOperationException("This class cannot be instantiated");
+    }
+
+    /**
+     * Returns the {@link Class} object with the specified name.
+     *
+     * <p>This method is a wrapper around {@link Class#forName(String)} that
+     * catches the checked exception and rethrows it as a {@link WrappedReflectiveOperationException}.
+     *
+     * <p>When running on Paper 1.20.5+, this method will remap the class name
+     * using the mappings built into the Paper jar.
+     *
+     * @param className the fully qualified name of the desired class
+     * @return the {@code Class} object for the class with the specified name
+     * @param <T> the type of the class
+     * @throws WrappedReflectiveOperationException if the class cannot be found
+     */
+    public static <T> @NotNull Class<T> getClass(@NotNull String className) {
+        // In Paper 1.20.5+, Paper remaps the server to Mojang mappings
+        if (MinecraftVersions.TRAILS_AND_TAILS.get(5).isAtLeast() && ServerVersions.isPaper()) {
+            ReflectionRemapper remapper = ReflectionRemapper.forReobfMappingsInPaperJar();
+            className = remapper.remapClassOrArrayName(className);
+        }
+
+        try {
+            // noinspection unchecked
+            return (Class<T>) Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            throw new WrappedReflectiveOperationException(e);
+        }
+    }
+
+    /**
+     * Returns the net.minecraft.server {@link Class} object with the specified name.
+     * This method calls {@link #getClass(String)} with the full class name constructed
+     * from the package name and class name.
+     *
+     * <p>We recommend using a <a href="https://mappings.dev/">mappings website</a> to find the
+     * correct package and class name. Always use the <b>Spigot mapped</b> package and class name.
+     *
+     * @param packageName the name of the <b>Spigot mapped</b> mojang package, without the
+     * "net.minecraft." prefix (e.g. "world.entity.player")
+     * @param className the mojang mapped class name (e.g. "EntityPlayer")
+     * @return the {@code Class} object for the class with the specified name
+     * @param <T> the type of the class
+     * @throws WrappedReflectiveOperationException if the class cannot be found
+     */
+    public static <T> @NotNull Class<T> getMinecraftClass(@NotNull String packageName, @NotNull String className) {
+
+        // In 1.17+, Spigot stopped remapping Mojang into 1 big package
+        if (MinecraftVersions.CAVES_AND_CLIFFS_1.isAtLeast()) {
+            return getClass("net.minecraft." + packageName + "." + className);
+        }
+
+        // In older versions, Mojang classes are in a single package: net.minecraft.server.<version>
+        return getClass("net.minecraft.server." + MinecraftVersions.getCurrent() + "." + className);
+    }
+
+    /**
+     * Returns the org.bukkit.craftbukkit {@link Class} object with the specified relative path.
+     * This method calls {@link #getClass(String)}.
+     *
+     * <p>For example, to get the class <code>org.bukkit.craftbukkit.v1_17_R1.entity.CraftPlayer</code>,
+     * you would call <code>getCraftBukkitClass("entity.CraftPlayer")</code>.
+     *
+     * @param classPath the relative path of the class, without the "org.bukkit.craftbukkit." prefix.
+     * @return the {@code Class} object for the class with the specified name
+     * @param <T> the type of the class
+     */
+    public static <T> @NotNull Class<T> getCraftBukkitClass(@NotNull String classPath) {
+        return getClass("org.bukkit.craftbukkit." + MinecraftVersions.getCurrent() + "." + classPath);
+    }
+
+    /**
+     * Returns the {@link FieldAccessor} for the specified field.
+     *
+     * @param clazz The class that owns the field.
+     * @param fieldName The name of the field.
+     * @return The {@link FieldAccessor} for the field.
+     */
+    public static @NotNull FieldAccessor getField(@NotNull Class<?> clazz, @NotNull String fieldName) {
+        try {
+            // In Paper 1.20.5+, Paper remaps the server to Mojang mappings
+            if (MinecraftVersions.TRAILS_AND_TAILS.get(5).isAtLeast() && ServerVersions.isPaper()) {
+                ReflectionRemapper remapper = ReflectionRemapper.forReobfMappingsInPaperJar();
+                fieldName = remapper.remapFieldName(clazz, fieldName);
+            }
+            return new FieldAccessor(clazz.getDeclaredField(fieldName));
+        } catch (ReflectiveOperationException e) {
+            throw new WrappedReflectiveOperationException(e);
+        }
+    }
+
+    /**
+     * Returns the {@link FieldAccessor} for the specified field. If no such field exists, an
+     * {@link IllegalArgumentException} is thrown.
+     *
+     * @param clazz The class that owns the field.
+     * @param fieldType The type of the field.
+     * @return The {@link FieldAccessor} for the field.
+     * @see #getField(Class, Class, int, Predicate)
+     */
+    public static @NotNull FieldAccessor getField(@NotNull Class<?> clazz, @NotNull Class<?> fieldType) {
+        return getField(clazz, fieldType, 0, null);
+    }
+
+    /**
+     * Returns the {@link FieldAccessor} for the specified field. If no such field exists, an
+     * {@link IllegalArgumentException} is thrown.
+     *
+     * @param clazz The class that owns the field.
+     * @param fieldType The type of the field.
+     * @param index The index of the field to get (in case there are multiple fields of the same type).
+     * @return The {@link FieldAccessor} for the field.
+     * @see #getField(Class, Class, int, Predicate)
+     */
+    public static @NotNull FieldAccessor getField(@NotNull Class<?> clazz, @NotNull Class<?> fieldType, int index) {
+        return getField(clazz, fieldType, index, null);
+    }
+
+    /**
+     * Returns the {@link FieldAccessor} for the specified field. If no such field exists, an
+     * {@link IllegalArgumentException} is thrown.
+     *
+     * <p>This method can be used to get the nth field of a certain type in a class. For example,
+     * to get the 2nd non-static field of type int in a class, you would call
+     * <code>getField(clazz, int.class, 2, IS_FIELD_NON_STATIC)</code>.
+     *
+     * @param clazz The class that owns the field.
+     * @param fieldType The type of the field.
+     * @param index The index of the field to get (in case there are multiple fields of the same type).
+     * @param predicate A predicate to filter the fields. If the predicate returns false, the field is skipped.
+     * @return The {@link FieldAccessor} for the field.
+     */
+    public static @NotNull FieldAccessor getField(@NotNull Class<?> clazz, @NotNull Class<?> fieldType, int index, @Nullable Predicate<? super Field> predicate) {
+        for (Field field : clazz.getDeclaredFields()) {
+            if (!fieldType.isAssignableFrom(field.getType()))
+                continue;
+            if (predicate != null && !predicate.test(field))
+                continue;
+            if (index-- > 0)
+                continue;
+
+            return new FieldAccessor(field);
+        }
+
+        // If no field was found, recursively check super class
+        if (clazz.getSuperclass() != null)
+            return getField(clazz.getSuperclass(), fieldType, index, predicate);
+
+        throw new IllegalArgumentException("No field of type " + fieldType.getName() + " found in class " + clazz.getName());
+    }
+
+    /**
+     * Returns the {@link MethodInvoker} for the specified method.
+     *
+     * @param clazz The class that owns the method.
+     * @param methodName The name of the method.
+     * @param parameterTypes The parameter types of the method.
+     * @return The {@link MethodInvoker} for the method.
+     */
+    public static @NotNull MethodInvoker getMethod(@NotNull Class<?> clazz, @NotNull String methodName, Class<?>... parameterTypes) {
+        try {
+            // In Paper 1.20.5+, Paper remaps the server to Mojang mappings
+            if (MinecraftVersions.TRAILS_AND_TAILS.get(5).isAtLeast() && ServerVersions.isPaper()) {
+                ReflectionRemapper remapper = ReflectionRemapper.forReobfMappingsInPaperJar();
+                methodName = remapper.remapMethodName(clazz, methodName);
+            }
+            return new MethodInvoker(clazz.getDeclaredMethod(methodName, parameterTypes));
+        } catch (ReflectiveOperationException e) {
+            throw new WrappedReflectiveOperationException(e);
+        }
+    }
+
+    /**
+     * Returns the {@link MethodInvoker} for the specified method. If no such method exists, an
+     * {@link IllegalArgumentException} is thrown.
+     *
+     * @param clazz The class that owns the method.
+     * @param returnType The return type of the method.
+     * @param parameterTypes The parameter types of the method.
+     * @return The {@link MethodInvoker} for the method.
+     * @see #getMethod(Class, Class, int, Predicate, Class...)
+     */
+    public static @NotNull MethodInvoker getMethod(@NotNull Class<?> clazz, @NotNull Class<?> returnType, Class<?>... parameterTypes) {
+        return getMethod(clazz, returnType, 0, null, parameterTypes);
+    }
+
+    /**
+     * Returns the {@link MethodInvoker} for the specified method. If no such method exists, an
+     * {@link IllegalArgumentException} is thrown.
+     *
+     * @param clazz The class that owns the method.
+     * @param returnType The return type of the method.
+     * @param index The index of the method to get (in case there are multiple methods with the same return type).
+     * @param parameterTypes The parameter types of the method.
+     * @return The {@link MethodInvoker} for the method.
+     * @see #getMethod(Class, Class, int, Predicate, Class...)
+     */
+    public static @NotNull MethodInvoker getMethod(@NotNull Class<?> clazz, @NotNull Class<?> returnType, int index, Class<?>... parameterTypes) {
+        return getMethod(clazz, returnType, index, null, parameterTypes);
+    }
+
+    /**
+     * Returns the {@link MethodInvoker} for the specified method. If no such method exists, an
+     * {@link IllegalArgumentException} is thrown.
+     *
+     * <p>This method can be used to get the nth method of a certain return type in a class. For example,
+     * to get the 2nd method with return type void in a class, you would call
+     * <code>getMethod(clazz, void.class, 2, null, parameterTypes)</code>.
+     *
+     * @param clazz The class that owns the method.
+     * @param returnType The return type of the method.
+     * @param index The index of the method to get (in case there are multiple methods with the same return type).
+     * @param predicate A predicate to filter the methods. If the predicate returns false, the method is skipped.
+     * @param parameterTypes The parameter types of the method.
+     * @return The {@link MethodInvoker} for the method.
+     */
+    public static @NotNull MethodInvoker getMethod(@NotNull Class<?> clazz, @NotNull Class<?> returnType, int index, @Nullable Predicate<? super Method> predicate, Class<?>... parameterTypes) {
+        for (Method method : clazz.getDeclaredMethods()) {
+            if (!returnType.isAssignableFrom(method.getReturnType()))
+                continue;
+            if (predicate != null && !predicate.test(method))
+                continue;
+            if (parameterTypes.length != method.getParameterCount())
+                continue;
+
+            // Each argument must be assignable from the parameter type
+            boolean match = true;
+            for (int i = 0; i < parameterTypes.length; i++) {
+                if (!parameterTypes[i].isAssignableFrom(method.getParameterTypes()[i])) {
+                    match = false;
+                    break;
+                }
+            }
+            if (!match)
+                continue;
+            if (index-- > 0)
+                continue;
+
+            return new MethodInvoker(method);
+        }
+
+        // If no method was found, recursively check super class
+        if (clazz.getSuperclass() != null)
+            return getMethod(clazz.getSuperclass(), returnType, index, predicate, parameterTypes);
+
+        throw new IllegalArgumentException("No method with return type " + returnType.getName() + " found in class " + clazz.getName());
+    }
+
+    /**
+     * Returns the {@link ConstructorInvoker} for the specified constructor.
+     *
+     * @param clazz The class that owns the constructor.
+     * @param parameterTypes The parameter types of the constructor.
+     * @return The {@link ConstructorInvoker} for the constructor.
+     * @param <T> The type of the class.
+     */
+    public static <T> @NotNull ConstructorInvoker<T> getConstructor(@NotNull Class<T> clazz, Class<?>... parameterTypes) {
+        try {
+            Constructor<T> constructor = clazz.getDeclaredConstructor(parameterTypes);
+            return new ConstructorInvoker<>(constructor);
+        } catch (ReflectiveOperationException e) {
+            throw new WrappedReflectiveOperationException(e);
+        }
+    }
+}

--- a/src/main/java/com/cjcrafter/foliascheduler/util/ReflectionUtil.java
+++ b/src/main/java/com/cjcrafter/foliascheduler/util/ReflectionUtil.java
@@ -257,8 +257,8 @@ public final class ReflectionUtil {
      * Returns the {@link MethodInvoker} for the specified method. If no such method exists, an
      * {@link IllegalArgumentException} is thrown.
      *
-     * <p>This method can be used to get the nth method of a certain return type in a class. For example,
-     * to get the 2nd method with return type void in a class, you would call
+     * <p>This method can be used to get the <code>n</code>th method of a certain return type in a
+     * class. For example, to get the 2nd method with return type void in a class, you would call
      * <code>getMethod(clazz, void.class, 2, null, parameterTypes)</code>.
      *
      * @param clazz The class that owns the method.

--- a/src/main/java/com/cjcrafter/foliascheduler/util/WrappedReflectiveOperationException.java
+++ b/src/main/java/com/cjcrafter/foliascheduler/util/WrappedReflectiveOperationException.java
@@ -1,0 +1,16 @@
+package com.cjcrafter.foliascheduler.util;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Wraps a {@link ReflectiveOperationException} in a {@link RuntimeException}.
+ *
+ * <p>By wrapping checked exceptions in a runtime exception, the caller does not
+ * need to handle the checked exception. This is useful when using reflection
+ * and the caller does not want to handle checked exceptions.
+ */
+public class WrappedReflectiveOperationException extends RuntimeException {
+    public WrappedReflectiveOperationException(@NotNull ReflectiveOperationException e) {
+        super(e);
+    }
+}

--- a/src/test/java/com/cjcrafter/foliascheduler/util/ReflectionUtilTest.java
+++ b/src/test/java/com/cjcrafter/foliascheduler/util/ReflectionUtilTest.java
@@ -1,0 +1,87 @@
+package com.cjcrafter.foliascheduler.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Member;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ReflectionUtilTest {
+
+    @Test
+    public void testGetNamedField() {
+        FieldAccessor field = ReflectionUtil.getField(Boolean.class, "TRUE");
+        assertEquals(Boolean.TRUE, field.get(null));
+    }
+
+    @Test
+    public void testSearchForStaticFinalFields() {
+        // This test is bad since the behavior will be the same if this predicate is null...
+        // Filters are properly tested in other test cases.
+        Predicate<Member> isStaticFinal = ReflectionUtil.IS_STATIC.and(ReflectionUtil.IS_FINAL);
+        FieldAccessor actualTrue = ReflectionUtil.getField(Boolean.class, Boolean.class, 0, isStaticFinal);
+        assertEquals(Boolean.TRUE, actualTrue.get(null));
+
+        FieldAccessor actualFalse = ReflectionUtil.getField(Boolean.class, Boolean.class, 1, isStaticFinal);
+        assertEquals(Boolean.FALSE, actualFalse.get(null));
+    }
+
+    @Test
+    public void testSearchForInstanceFields() {
+        FieldAccessor wrappedValueField = ReflectionUtil.getField(Boolean.class, boolean.class);
+        assertEquals(true, wrappedValueField.get(Boolean.TRUE));
+        assertEquals(false, wrappedValueField.get(Boolean.FALSE));
+    }
+
+    @Test
+    public void testGetNamedMethod() {
+        MethodInvoker method = ReflectionUtil.getMethod(Boolean.class, "valueOf", String.class);
+        assertEquals(Boolean.TRUE, method.invoke(null, "true"));
+    }
+
+    @Test
+    public void testSearchForStaticMethods() {
+        MethodInvoker valueOf = ReflectionUtil.getMethod(Boolean.class, Boolean.class, 0, ReflectionUtil.IS_STATIC, String.class);
+        assertEquals(Boolean.TRUE, valueOf.invoke(null, "true"));
+        assertEquals(Boolean.FALSE, valueOf.invoke(null, "false"));
+    }
+
+    @Test
+    public void testFilters() {
+        // This test tries many different ways of getting the same field
+        FieldAccessor w = ReflectionUtil.getField(TestFilterObject.class, int.class, 0, ReflectionUtil.IS_NOT_STATIC);
+        assertEquals("w", w.getField().getName());
+        w = ReflectionUtil.getField(TestFilterObject.class, int.class, 0, ReflectionUtil.IS_NOT_FINAL);
+        assertEquals("w", w.getField().getName());
+        w = ReflectionUtil.getField(TestFilterObject.class, int.class, 1);
+        assertEquals("w", w.getField().getName());
+
+        FieldAccessor x = ReflectionUtil.getField(TestFilterObject.class, int.class, 0, ReflectionUtil.IS_NOT_STATIC.and(ReflectionUtil.IS_PRIVATE));
+        assertEquals("x", x.getField().getName());
+        x = ReflectionUtil.getField(TestFilterObject.class, int.class, 0, ReflectionUtil.IS_NOT_FINAL.and(ReflectionUtil.IS_PRIVATE));
+        assertEquals("x", x.getField().getName());
+        x = ReflectionUtil.getField(TestFilterObject.class, int.class, 0, ReflectionUtil.IS_PRIVATE);
+        assertEquals("x", x.getField().getName());
+        x = ReflectionUtil.getField(TestFilterObject.class, int.class, 2);
+        assertEquals("x", x.getField().getName());
+
+        FieldAccessor y = ReflectionUtil.getField(TestFilterObject.class, int.class, 1, ReflectionUtil.IS_NOT_STATIC.and(ReflectionUtil.IS_PRIVATE));
+        assertEquals("y", y.getField().getName());
+        y = ReflectionUtil.getField(TestFilterObject.class, int.class, 1, ReflectionUtil.IS_NOT_FINAL.and(ReflectionUtil.IS_PRIVATE));
+        assertEquals("y", y.getField().getName());
+        y = ReflectionUtil.getField(TestFilterObject.class, int.class, 1, ReflectionUtil.IS_PRIVATE);
+        assertEquals("y", y.getField().getName());
+        y = ReflectionUtil.getField(TestFilterObject.class, int.class, 3);
+        assertEquals("y", y.getField().getName());
+
+        FieldAccessor z = ReflectionUtil.getField(TestFilterObject.class, int.class, 2, ReflectionUtil.IS_NOT_STATIC.and(ReflectionUtil.IS_PRIVATE));
+        assertEquals("z", z.getField().getName());
+        z = ReflectionUtil.getField(TestFilterObject.class, int.class, 2, ReflectionUtil.IS_NOT_FINAL.and(ReflectionUtil.IS_PRIVATE));
+        assertEquals("z", z.getField().getName());
+        z = ReflectionUtil.getField(TestFilterObject.class, int.class, 2, ReflectionUtil.IS_PRIVATE);
+        assertEquals("z", z.getField().getName());
+        z = ReflectionUtil.getField(TestFilterObject.class, int.class, 4);
+        assertEquals("z", z.getField().getName());
+    }
+}

--- a/src/test/java/com/cjcrafter/foliascheduler/util/TestFilterObject.java
+++ b/src/test/java/com/cjcrafter/foliascheduler/util/TestFilterObject.java
@@ -1,0 +1,16 @@
+package com.cjcrafter.foliascheduler.util;
+
+import java.util.function.Predicate;
+
+/**
+ * Incomplete class used in {@link ReflectionUtilTest} to test the predicates in
+ * {@link ReflectionUtil#getField(Class, Class, int, Predicate)} and
+ * {@link ReflectionUtil#getMethod(Class, Class, int, Predicate, Class...)}.
+ */
+public class TestFilterObject {
+    public static final int STATIC_FINAL_INT = 0;
+    public int w;
+    private int x;
+    private int y;
+    private int z;
+}


### PR DESCRIPTION
Using Reflection on Spigot/Paper/Folia is difficult because Paper/Folia remap spigot mappings. The paper plugin remapper does a great job remapping all classes/methods/fields, but it can't automatically handle Reflection.

This PR seeks to fix that by building in Paper's [remapping tool](https://github.com/jpenilla/reflection-remapper) into a simple reflection utility. Of course, that reflection utility should have some version handling for CraftBukkit and NMS classes, to improve cross-version support.