### PR TITLE
fix the completable future returning null in BukkitTask

### DIFF
--- a/platforms/spigot/src/main/java/com/cjcrafter/foliascheduler/bukkit/BukkitTask.java
+++ b/platforms/spigot/src/main/java/com/cjcrafter/foliascheduler/bukkit/BukkitTask.java
@@ -81,6 +81,6 @@ public class BukkitTask<T> implements TaskImplementation<T> {
 
     @Override
     public @NotNull CompletableFuture<TaskImplementation<T>> asFuture() {
-        return null;
+        return future;
     }
 }


### PR DESCRIPTION
Looks like we forgot to hook up the completable future... This caused any plugin using the future to break on any non-paper server