### PR TITLE
Cj/async teleport

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Spigot's scheduler (using `BukkitRunnable`, which allows basically any server ve
 <dependency>
     <groupId>com.cjcrafter</groupId>
     <artifactId>foliascheduler</artifactId>
-    <version>0.5.0</version>
+    <version>0.6.0</version>
 </dependency>
 ```
 
@@ -36,7 +36,7 @@ Spigot's scheduler (using `BukkitRunnable`, which allows basically any server ve
     <dependency>
         <groupId>com.cjcrafter</groupId>
         <artifactId>foliascheduler</artifactId>
-        <version>0.5.0</version>
+        <version>0.6.0</version>
     </dependency>
 </dependencies>
 
@@ -75,7 +75,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.cjcrafter:foliascheduler:0.5.0")
+    implementation("com.cjcrafter:foliascheduler:0.6.0")
 }
 ```
 
@@ -96,7 +96,7 @@ repositories {
 
 dependencies {
     // TODO add your version of Spigot/Paper here
-    implementation("com.cjcrafter:foliascheduler:0.5.0")
+    implementation("com.cjcrafter:foliascheduler:0.6.0")
 }
 
 // See https://github.com/Minecrell/plugin-yml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "com.cjcrafter"
-version = "0.5.0"
+version = "0.6.0"
 
 val githubOwner = "CJCrafter"
 val githubRepo = "FoliaScheduler"

--- a/platforms/folia/src/main/java/com/cjcrafter/foliascheduler/folia/FoliaServer.java
+++ b/platforms/folia/src/main/java/com/cjcrafter/foliascheduler/folia/FoliaServer.java
@@ -10,9 +10,12 @@ import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
 
 @ApiStatus.Internal
 public class FoliaServer implements ServerImplementation {
@@ -87,5 +90,10 @@ public class FoliaServer implements ServerImplementation {
     public void cancelTasks() {
         globalScheduler.cancelTasks();
         asyncScheduler.cancelTasks();
+    }
+
+    @Override
+    public @NotNull CompletableFuture<Boolean> teleportAsync(@NotNull Entity entity, @NotNull Location location, @NotNull PlayerTeleportEvent.TeleportCause cause) {
+        return entity.teleportAsync(location, cause);
     }
 }

--- a/platforms/spigot/src/main/java/com/cjcrafter/foliascheduler/bukkit/BukkitServer.java
+++ b/platforms/spigot/src/main/java/com/cjcrafter/foliascheduler/bukkit/BukkitServer.java
@@ -9,9 +9,13 @@ import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
 
 @ApiStatus.Internal
 public class BukkitServer implements ServerImplementation {
@@ -87,5 +91,26 @@ public class BukkitServer implements ServerImplementation {
     @Override
     public void cancelTasks() {
         owningPlugin.getServer().getScheduler().cancelTasks(owningPlugin);
+    }
+
+    @Override
+    public @NotNull CompletableFuture<Boolean> teleportAsync(@NotNull Entity entity, @NotNull Location location, PlayerTeleportEvent.@NotNull TeleportCause cause) {
+        // Check if the teleportAsync method is supported
+        if (false) {
+            // TODO
+        }
+
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+        entity(entity).run(task -> {
+            try {
+                entity.teleport(location);
+                future.complete(true);
+            } catch (Throwable ex) {
+                owningPlugin.getLogger().log(Level.SEVERE, "Failed to teleport entity", ex);
+                future.complete(false);
+            }
+        });
+
+        return future;
     }
 }

--- a/src/main/java/com/cjcrafter/foliascheduler/ServerImplementation.java
+++ b/src/main/java/com/cjcrafter/foliascheduler/ServerImplementation.java
@@ -5,8 +5,11 @@ import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
 
 public interface ServerImplementation {
 
@@ -139,4 +142,35 @@ public interface ServerImplementation {
      * @see <a href="https://github.com/CJCrafter/FoliaScheduler/issues/28">Issue #28</a>
      */
     void cancelTasks();
+
+    /**
+     * Teleports an entity to a location. If chunks need to be loaded, those chunks will be loaded
+     * asynchronously. Shortcut for {@link #teleportAsync(Entity, Location, PlayerTeleportEvent.TeleportCause)}.
+     *
+     * @param entity The entity to teleport
+     * @param location The location to teleport the entity to
+     * @return A future that completes when the entity is teleported, or the teleport fails
+     */
+    default @NotNull CompletableFuture<Boolean> teleportAsync(@NotNull Entity entity, @NotNull Location location) {
+        return teleportAsync(entity, location, PlayerTeleportEvent.TeleportCause.PLUGIN);
+    }
+
+    /**
+     * Teleports an entity to a location. If chunks need to be loaded, those chunks will be loaded
+     * asynchronously.
+     *
+     * <p>The returned {@link CompletableFuture future} will complete when the entity is teleported,
+     * or the teleport fails. If the teleport fails, the future will complete with a value of
+     * {@code false}.
+     *
+     * <p>Note that this method is only asynchronous on Paper servers, versions 1.13 and later. On
+     * other servers, this method will be delegated to a synchronous task that executed
+     * {@link Entity#teleport(Location)} in the main thread (which may lead to lag spikes).
+     *
+     * @param entity The entity to teleport
+     * @param location The location to teleport the entity to
+     * @param cause The cause of the teleport
+     * @return A future that completes when the entity is teleported, or the teleport fails
+     */
+    @NotNull CompletableFuture<Boolean> teleportAsync(@NotNull Entity entity, @NotNull Location location, @NotNull PlayerTeleportEvent.TeleportCause cause);
 }

--- a/src/main/java/com/cjcrafter/foliascheduler/ServerImplementation.java
+++ b/src/main/java/com/cjcrafter/foliascheduler/ServerImplementation.java
@@ -164,7 +164,7 @@ public interface ServerImplementation {
      * {@code false}.
      *
      * <p>Note that this method is only asynchronous on Paper servers, versions 1.13 and later. On
-     * other servers, this method will be delegated to a synchronous task that executed
+     * other servers, this method will be delegated to a synchronous task that executes
      * {@link Entity#teleport(Location)} in the main thread (which may lead to lag spikes).
      *
      * @param entity The entity to teleport


### PR DESCRIPTION
Fixes https://github.com/CJCrafter/VivecraftSpigot/issues/6

Basically, Folia only supports async teleport methods, so we should have some way to do that while maintaining Spigot support. 